### PR TITLE
Add env vars to env dev and Vercel

### DIFF
--- a/packages/nextjs/.env.development
+++ b/packages/nextjs/.env.development
@@ -1,1 +1,6 @@
+
+NEXT_PUBLIC_BG_BACKEND=https://buidlguidl-v3.ew.r.appspot.com
+
 POSTGRES_URL="postgresql://postgres:mysecretpassword@localhost:5432/postgres"
+AUTOGRADING_SERVER=
+BG_BACKEND_API_KEY=


### PR DESCRIPTION
Added the following ENV vars to Vercel (and `.env.development`)

```env
// To make request to BG (see if user is there already, create new user from SREv2, etc)
NEXT_PUBLIC_BG_BACKEND=https://buidlguidl-v3.ew.r.appspot.com
// Not secret, but since we'll only be using it on the backend for now... keeping it private
AUTOGRADING_SERVER=
// This will be used when creating a BG user from SREv2 (#60)
BG_BACKEND_API_KEY=
```

You can get the values from Vercel. 

Fixes #59 