### PR TITLE
await for isValidEIP function

### DIFF
--- a/packages/nextjs/app/api/users/join-bg/route.ts
+++ b/packages/nextjs/app/api/users/join-bg/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Required challenges have not been completed" }, { status: 400 });
     }
 
-    const isValidSignature = isValidEIP712JoinBGSignature({ address, signature });
+    const isValidSignature = await isValidEIP712JoinBGSignature({ address, signature });
 
     if (!isValidSignature) {
       return NextResponse.json({ error: "Invalid signature" }, { status: 401 });

--- a/packages/nextjs/app/api/users/register/route.ts
+++ b/packages/nextjs/app/api/users/register/route.ts
@@ -21,7 +21,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "User already registered" }, { status: 401 });
     }
 
-    const isValidSignature = isValidEIP712UserRegisterSignature({ address, signature });
+    const isValidSignature = await isValidEIP712UserRegisterSignature({ address, signature });
 
     if (!isValidSignature) {
       return NextResponse.json({ error: "Invalid signature" }, { status: 401 });


### PR DESCRIPTION
### Description: 

Fixes #80 

Ohh it seems that we didn't await while using `isValieEIP712` uitilites that's why this occurred in certain routes because it was returning `promise` instead of `boolean` which always resulted in signature being correct because we checking the promise. 



https://github.com/user-attachments/assets/c92d0bae-bec5-4f02-9556-64b597660635


