### PR TITLE
Add Chain ID and verifying contract to EIP712 domain

### DIFF
--- a/packages/nextjs/services/eip712/common.ts
+++ b/packages/nextjs/services/eip712/common.ts
@@ -3,6 +3,8 @@ import { RecoverTypedDataAddressParameters, recoverTypedDataAddress } from "viem
 export const EIP_712_DOMAIN = {
   name: "SpeedRunEthereum",
   version: "1",
+  chainId: 1,
+  verifyingContract: "0x0000000000000000000000000000000000000000",
 } as const;
 
 export const isValidEip712Signature = async ({


### PR DESCRIPTION
Because of https://github.com/MetaMask/metamask-extension/issues/31606 (https://github.com/MetaMask/core/commit/5756b6a4f0935e1b4d53cb7444d30e1ad89e392b#r154933945)

The new Metamask version (12.15.1) fails to sign SRE off-chain messages.

This PR add chain ID and verifying contract (0x0) which bypasses the error