### PR TITLE
Add GH action to store a daily database backup in AWS

### DIFF
--- a/.github/workflows/daily-db-backup.yml
+++ b/.github/workflows/daily-db-backup.yml
@@ -1,0 +1,69 @@
+name: daily-db-backup
+
+on:
+  schedule:
+    - cron: "0 5 * * *" # Runs at 5 am ET (us-east-1)
+  workflow_dispatch:
+
+jobs:
+  db-backup:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+
+    env:
+      RETENTION: 7
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      IAM_ROLE: ${{ secrets.IAM_ROLE }}
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+      AWS_REGION: "us-east-1"
+      PG_VERSION: "15"
+
+    steps:
+      - name: Install PostgreSQL
+        run: |
+          sudo apt update
+          yes '' | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+          sudo apt install -y postgresql-${{ env.PG_VERSION }}
+
+      - name: Set PostgreSQL binary path
+        run: echo "POSTGRES=/usr/lib/postgresql/${{ env.PG_VERSION }}/bin" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set file, folder and path variables
+        run: |
+          GZIP_NAME="$(date +'%Y%m%d@%H%M%S').sql.gz"
+          FOLDER_NAME="${{ github.workflow }}"
+          UPLOAD_PATH="s3://${{ env.S3_BUCKET_NAME }}/${FOLDER_NAME}/${GZIP_NAME}"
+
+          echo "GZIP_NAME=${GZIP_NAME}" >> $GITHUB_ENV
+          echo "FOLDER_NAME=${FOLDER_NAME}" >> $GITHUB_ENV
+          echo "UPLOAD_PATH=${UPLOAD_PATH}" >> $GITHUB_ENV
+
+      - name: Create folder if it doesn't exist
+        run: |
+          if ! aws s3api head-object --bucket ${{ env.S3_BUCKET_NAME }} --key "${{ env.FOLDER_NAME }}/" 2>/dev/null; then
+            aws s3api put-object --bucket ${{ env.S3_BUCKET_NAME }} --key "${{ env.FOLDER_NAME }}/"
+          fi
+
+      - name: Run pg_dump
+        run: |
+          $POSTGRES/pg_dump ${{ env.DATABASE_URL }} | gzip > "${{ env.GZIP_NAME }}"
+
+      - name: Empty bucket of old files
+        run: |
+          THRESHOLD_DATE=$(date -d "-${{ env.RETENTION }} days" +%Y-%m-%dT%H:%M:%SZ)
+          aws s3api list-objects --bucket ${{ env.S3_BUCKET_NAME }} --prefix "${{ env.FOLDER_NAME }}/" --query "Contents[?LastModified<'${THRESHOLD_DATE}'] | [?ends_with(Key, '.gz')].{Key: Key}" --output text | while read -r file; do
+            aws s3 rm "s3://${{ env.S3_BUCKET_NAME }}/${file}"
+          done
+
+      - name: Upload to bucket
+        run: |
+          aws s3 cp "${{ env.GZIP_NAME }}" "${{ env.UPLOAD_PATH }}" --region ${{ env.AWS_REGION }}

--- a/.github/workflows/daily-db-backup.yml
+++ b/.github/workflows/daily-db-backup.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
 
     env:
-      RETENTION: 7
+      RETENTION: 30
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       IAM_ROLE: ${{ secrets.IAM_ROLE }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/weekly-db-backup.yml
+++ b/.github/workflows/weekly-db-backup.yml
@@ -1,8 +1,8 @@
-name: daily-db-backup
+name: weekly-db-backup
 
 on:
   schedule:
-    - cron: "0 5 * * *" # Runs at 5 am ET (us-east-1)
+    - cron: "0 5 * * 0" # Weekly backup: Runs at 5 am ET (us-east-1) every Sunday
   workflow_dispatch:
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
       id-token: write
 
     env:
-      RETENTION: 30
+      RETENTION: 180 # 6 months of backups
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       IAM_ROLE: ${{ secrets.IAM_ROLE }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}


### PR DESCRIPTION
First step to tackle #5 

This PR adds a GH action to make a daily backup from neon database and store it in a AWS S3 bucket. 

This will be complementary to the [native Instant Restore](https://neon.tech/docs/manage/backups) from Neon (1 to 7 days retention depending if we upgrade to the first paid plan), which seems to be better for "hot" restores, since it seems you can instantly restore a db snapshot if you need to execute a rollback.

I followed the guide from the previous link and tested it with staging database in my [local repo](https://github.com/Pabl0cks/sre-aws-backups), verifying that I could restore the database and could access all the data locally.

In this repo I changed the `PG_VERSION` from 17 (staging) to 15 (prod), and we'd need to set the following environment variables in this repo:

- `DATABASE_URL`
- `IAM_ROLE`
- `AWS_ACCOUNT_ID`
- `S3_BUCKET_NAME`

`DATABASE_URL` maybe is already set or with a different name, I can tweak it in the script if so. Can send you the rest of the values in a private msg.

Once set, we should be able to execute it from the "Actions" tab and the backup should appear in our AWS S3 backup, under the folder with the action name ("daily-db-backup" in this case).