### PR TITLE
Builds schema and data seed

### DIFF
--- a/packages/nextjs/services/database/migrations/0003_certain_squadron_supreme.sql
+++ b/packages/nextjs/services/database/migrations/0003_certain_squadron_supreme.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "build_likes" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"build_id" integer NOT NULL,
+	"liker_address" varchar(42) NOT NULL,
+	"liked_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "builds" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"desc" text,
+	"build_type" varchar(50),
+	"builder_address" varchar(42) NOT NULL,
+	"co_builder_addresses" varchar(42)[],
+	"demo_url" varchar(255),
+	"video_url" varchar(255),
+	"image_url" varchar(255),
+	"github_url" varchar(255),
+	"submitted_timestamp" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "build_likes" ADD CONSTRAINT "build_likes_build_id_builds_id_fk" FOREIGN KEY ("build_id") REFERENCES "public"."builds"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "build_likes" ADD CONSTRAINT "build_likes_liker_address_users_user_address_fk" FOREIGN KEY ("liker_address") REFERENCES "public"."users"("user_address") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "builds" ADD CONSTRAINT "builds_builder_address_users_user_address_fk" FOREIGN KEY ("builder_address") REFERENCES "public"."users"("user_address") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "build_like_unique_idx" ON "build_likes" USING btree ("build_id","liker_address");--> statement-breakpoint
+CREATE INDEX "build_builder_idx" ON "builds" USING btree ("builder_address");--> statement-breakpoint
+CREATE INDEX "build_co_builders_idx" ON "builds" USING btree ("co_builder_addresses");

--- a/packages/nextjs/services/database/migrations/meta/0003_snapshot.json
+++ b/packages/nextjs/services/database/migrations/meta/0003_snapshot.json
@@ -1,0 +1,656 @@
+{
+  "id": "d12f6801-a2f6-4355-9da4-807f7289de70",
+  "prevId": "9c5331d3-f890-49c2-9c37-cd28d054ab7e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_link": {
+          "name": "telegram_link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.build_likes": {
+      "name": "build_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liker_address": {
+          "name": "liker_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked_at": {
+          "name": "liked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "build_like_unique_idx": {
+          "name": "build_like_unique_idx",
+          "columns": [
+            {
+              "expression": "build_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "liker_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "build_likes_build_id_builds_id_fk": {
+          "name": "build_likes_build_id_builds_id_fk",
+          "tableFrom": "build_likes",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "build_likes_liker_address_users_user_address_fk": {
+          "name": "build_likes_liker_address_users_user_address_fk",
+          "tableFrom": "build_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "liker_address"
+          ],
+          "columnsTo": [
+            "user_address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.builds": {
+      "name": "builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desc": {
+          "name": "desc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_type": {
+          "name": "build_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "builder_address": {
+          "name": "builder_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_builder_addresses": {
+          "name": "co_builder_addresses",
+          "type": "varchar(42)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_url": {
+          "name": "demo_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_timestamp": {
+          "name": "submitted_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "build_builder_idx": {
+          "name": "build_builder_idx",
+          "columns": [
+            {
+              "expression": "builder_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "build_co_builders_idx": {
+          "name": "build_co_builders_idx",
+          "columns": [
+            {
+              "expression": "co_builder_addresses",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "builds_builder_address_users_user_address_fk": {
+          "name": "builds_builder_address_users_user_address_fk",
+          "tableFrom": "builds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "builder_address"
+          ],
+          "columnsTo": [
+            "user_address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenge_name": {
+          "name": "challenge_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autograding": {
+          "name": "autograding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "preview_image": {
+          "name": "preview_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_link": {
+          "name": "external_link",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenges": {
+      "name": "user_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frontend_url": {
+          "name": "frontend_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_url": {
+          "name": "contract_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_comment": {
+          "name": "review_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "review_action": {
+          "name": "review_action",
+          "type": "review_action_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_challenge_lookup_idx": {
+          "name": "user_challenge_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_challenge_review_idx": {
+          "name": "user_challenge_review_idx",
+          "columns": [
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenges_user_address_users_user_address_fk": {
+          "name": "user_challenges_user_address_users_user_address_fk",
+          "tableFrom": "user_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_address"
+          ],
+          "columnsTo": [
+            "user_address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenges_challenge_id_challenges_id_fk": {
+          "name": "user_challenges_challenge_id_challenges_id_fk",
+          "tableFrom": "user_challenges",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USER'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "social_telegram": {
+          "name": "social_telegram",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_x": {
+          "name": "social_x",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_github": {
+          "name": "social_github",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_instagram": {
+          "name": "social_instagram",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_discord": {
+          "name": "social_discord",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_email": {
+          "name": "social_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_status": {
+          "name": "batch_status",
+          "type": "batch_user_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idUniqueIndex": {
+          "name": "idUniqueIndex",
+          "columns": [
+            {
+              "expression": "lower(\"user_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_batch_id_batches_id_fk": {
+          "name": "users_batch_id_batches_id_fk",
+          "tableFrom": "users",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.batch_status_enum": {
+      "name": "batch_status_enum",
+      "schema": "public",
+      "values": [
+        "closed",
+        "open"
+      ]
+    },
+    "public.batch_user_status_enum": {
+      "name": "batch_user_status_enum",
+      "schema": "public",
+      "values": [
+        "graduate",
+        "candidate"
+      ]
+    },
+    "public.review_action_enum": {
+      "name": "review_action_enum",
+      "schema": "public",
+      "values": [
+        "REJECTED",
+        "ACCEPTED",
+        "SUBMITTED"
+      ]
+    },
+    "public.user_role_enum": {
+      "name": "user_role_enum",
+      "schema": "public",
+      "values": [
+        "USER",
+        "BUILDER",
+        "ADMIN"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/nextjs/services/database/migrations/meta/_journal.json
+++ b/packages/nextjs/services/database/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1744784080351,
       "tag": "0002_friendly_valeria_richards",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1745228267810,
+      "tag": "0003_certain_squadron_supreme",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/nextjs/services/database/seed.data.example.ts
+++ b/packages/nextjs/services/database/seed.data.example.ts
@@ -1,4 +1,4 @@
-import { batches, challenges, userChallenges, users } from "./config/schema";
+import { batches, buildLikes, builds, challenges, userChallenges, users } from "./config/schema";
 import { BatchStatus, BatchUserStatus, ChallengeId, ReviewAction, UserRole } from "./config/types";
 
 export const SEED_DATA_VERSION = "1.1.0";
@@ -390,3 +390,88 @@ export const seedBatches: (typeof batches.$inferInsert)[] = [
     contractAddress: "0x0000000000000000000000000000000000000000",
   },
 ];
+
+export const seedBuilds: (typeof builds.$inferInsert)[] = [
+  {
+    name: "DynOS 95",
+    desc: "Platform to improve the onboarding experience to web3, providing a friendly environment where users can connect to any DApps with email and social accounts, powered by Dynamic and ERC4337 Account Abstraction. ETHGlobal London 2024 Hackathon finalist.",
+    buildType: "dapp",
+    builderAddress: "0xB4F53bd85c00EF22946d24Ae26BC38Ac64F5E7B1",
+    coBuilderAddresses: [
+      "0x000084821704d731438d2D06f4295e1AB0ace7D8",
+      "0x014EC6296B3493f0f59a3FE90E0FFf377fb8826a",
+      "0x01B2686Bd146bFc3F4B3DD6F7F86f26ac7c2f7Fd",
+    ],
+    demoUrl: "https://dynos95.vercel.app/",
+    videoUrl: "https://www.youtube.com/watch?v=iBX2zjECesU",
+    imageUrl: "https://storage.googleapis.com/buidlguidl-v3.appspot.com/builds/b651fcb278a4cf392309b1101.png",
+    githubUrl: "https://github.com/carletex/DynOS-95",
+    submittedTimestamp: new Date("2023-05-15"),
+  },
+  {
+    name: "ABI Ninja",
+    desc: "Interact with any contract on Ethereum. Just need the Contract address (if it's verified) or its ABI + Contract address.",
+    buildType: "dapp",
+    builderAddress: "0x000084821704d731438d2D06f4295e1AB0ace7D8",
+    coBuilderAddresses: [],
+    demoUrl: "https://abi.ninja/",
+    videoUrl: null,
+    imageUrl: "https://storage.googleapis.com/buidlguidl-v3.appspot.com/builds/c7329e266108aec34c81a0200.png",
+    githubUrl: "https://github.com/BuidlGuidl/abi.ninja",
+    submittedTimestamp: new Date("2023-06-20"),
+  },
+  {
+    name: "ETH Man",
+    desc: "ETH Man reacts to live ETH price using Chainlink oracles! He is happy 🙂 when it's up 📈 and sad 🙁 when it's down 📉 than the previous value. (Dynamic face, colors on chain SVG NFT). 100+ already minted!",
+    buildType: "dapp",
+    builderAddress: "0x014EC6296B3493f0f59a3FE90E0FFf377fb8826a",
+    coBuilderAddresses: ["0xB4F53bd85c00EF22946d24Ae26BC38Ac64F5E7B1"],
+    demoUrl: "https://ethman-sb.surge.sh/",
+    videoUrl: null,
+    imageUrl: "https://storage.googleapis.com/buidlguidl-v3.appspot.com/builds/3c09940f8645e7dfd053b7a00.jpeg",
+    githubUrl: "https://github.com/technophile-04/ethMan",
+    submittedTimestamp: new Date("2023-07-10"),
+  },
+  {
+    name: "Smart-Chain",
+    desc: "A basic/minimal supply chain DApp for solving issues in Luxury goods supply chain",
+    buildType: "dapp",
+    builderAddress: "0x01B2686Bd146bFc3F4B3DD6F7F86f26ac7c2f7Fd",
+    coBuilderAddresses: ["0xB4F53bd85c00EF22946d24Ae26BC38Ac64F5E7B1", "0x000084821704d731438d2D06f4295e1AB0ace7D8"],
+    demoUrl: "https://nextjs-blond-nine-41.vercel.app/",
+    videoUrl: "https://youtu.be/N13b0mEgo3I",
+    imageUrl: "https://storage.googleapis.com/buidlguidl-v3.appspot.com/builds/6c5b8cdbdf678bd7af4b31e01.jpeg",
+    githubUrl: "https://github.com/technophile-04/Spaghetti_Coders_1337_LOC5.0",
+    submittedTimestamp: new Date("2023-08-05"),
+  },
+];
+
+export const seedBuildLikes: Array<Omit<typeof buildLikes.$inferInsert, "buildId"> & { buildName: string }> = [
+  {
+    buildName: "DynOS 95",
+    likerAddress: "0x014EC6296B3493f0f59a3FE90E0FFf377fb8826a",
+    likedAt: new Date("2023-05-14"),
+  },
+  {
+    buildName: "DynOS 95",
+    likerAddress: "0x01B2686Bd146bFc3F4B3DD6F7F86f26ac7c2f7Fd",
+    likedAt: new Date("2023-05-14"),
+  },
+  {
+    buildName: "ABI Ninja",
+    likerAddress: "0xB4F53bd85c00EF22946d24Ae26BC38Ac64F5E7B1",
+    likedAt: new Date("2023-05-16"),
+  },
+  {
+    buildName: "ETH Man",
+    likerAddress: "0x000084821704d731438d2D06f4295e1AB0ace7D8",
+    likedAt: new Date("2023-05-18"),
+  },
+  {
+    buildName: "Smart-Chain",
+    likerAddress: "0x014EC6296B3493f0f59a3FE90E0FFf377fb8826a",
+    likedAt: new Date("2023-05-20"),
+  },
+];
+
+export const buildsData = [];


### PR DESCRIPTION
Creating this draft to discuss the way to tackle #138

- Initial database fields similar to BG builds. Some notes:
   - Changed `id` to autonumeric field
   - Didn't add `featured` field, thinking we probably should be neutral in SRE and don't feature builds by our own
   - Importing "BG like system" to have a initial social validation system that we could use to sort builds.
   - Importing the `builderAddress` + `coBuilderAddresses` approach because I like the idea of having a main builder (owner?) responsible of having up to date the build data, which is a SRE builder, and coBuilders could be builders not registered in SRE.
   - Initially only using one categorized field as we had in BG (build type), but I think we should probably improve this categorization by adding 1 or 2 extra fields.

**Categorization proposal idea** (with examples)

#### **Level 1: Build Type (high level categorization similar to BG)**
- Dapp
- Extension
- Infrastructure
- Challenge submission
- Education
- Design
- Other


#### **Level 2: Build Category**
- DeFi
- Game
- NFT
- Governance
- Social
- Marketplace
- Dev tooling


#### **Level 3: Tech Stack**
- Scaffold-ETH / Scaffold-ETH-2
- Hardhat
- Foundry
- Next.js
- Ethers
- Viem
- Wagmi

In case we decide to go to a multiple field categorization =>  TBD how to manage the different categorizations in database.  Should all of them be enums, or just build type - level 1?
