### PR TITLE
Loading spinner on builders count

### DIFF
--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -200,9 +200,9 @@ export default function BuildersPage() {
         </Link>
       </div>
 
-      <div className="text-base mt-4 font-medium flex justify-center gap-2">
-        Total Builders:{" "}
-        {isLoading ? <span className="loading loading-spinner loading-xs ml-1"></span> : totalDBRowCount}
+      <div className="text-base mt-4 font-medium flex justify-center gap-1">
+        <span>Total Builders:</span>
+        {isLoading ? <span className="loading loading-spinner loading-xs"></span> : totalDBRowCount}
       </div>
       <div
         onScroll={e => fetchMoreOnBottomReached(e.currentTarget)}

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -200,7 +200,10 @@ export default function BuildersPage() {
         </Link>
       </div>
 
-      <div className="text-base mt-4 font-medium">Total builders: {totalDBRowCount}</div>
+      <div className="text-base mt-4 font-medium flex justify-center gap-2">
+        Total Builders:{" "}
+        {isLoading ? <span className="loading loading-spinner loading-xs ml-1"></span> : totalDBRowCount}
+      </div>
       <div
         onScroll={e => fetchMoreOnBottomReached(e.currentTarget)}
         ref={tableContainerRef}


### PR DESCRIPTION
Tiny thing: show spinner instead of `0` while loading the builders on the /builders page

![image](https://github.com/user-attachments/assets/bee42f3f-0320-4e3c-b924-75463606ac64)

![image](https://github.com/user-attachments/assets/b88122d3-853b-41ec-9c4d-03ebbbb2eba2)
