### PR TITLE
fix: table header

### DIFF
--- a/packages/nextjs/components/InfiniteTable.tsx
+++ b/packages/nextjs/components/InfiniteTable.tsx
@@ -155,7 +155,7 @@ export default function InfiniteTable<T>({
       >
         {/* Even though we're still using sematic table tags, we must use CSS grid and flexbox for dynamic row heights */}
         <table style={{ display: "grid" }} className="table">
-          <thead className="grid sticky top-0 z-10" ref={tableHeader}>
+          <thead className="grid sticky top-0 z-10 bg-base-100" ref={tableHeader}>
             {table.getHeaderGroups().map(headerGroup => (
               <tr key={headerGroup.id} className="flex w-full text-sm">
                 {headerGroup.headers.map(header => {


### PR DESCRIPTION
After last table update, header background was removed

This micro pr fixed this

before:
<img width="1517" alt="Screenshot 2025-04-25 at 12 18 33" src="https://github.com/user-attachments/assets/4fbf2be9-3d13-495f-8828-cae4703fc2bf" />

after:
<img width="1489" alt="Screenshot 2025-04-25 at 12 18 51" src="https://github.com/user-attachments/assets/c7fc5889-3e82-4962-a2e8-cc415f22b6d3" />
