### PR TITLE
Use BG Mainnet RPC

### DIFF
--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -9,6 +9,7 @@ export type ScaffoldConfig = {
 };
 
 export const DEFAULT_ALCHEMY_API_KEY = "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
+export const BG_MAINNET_RPC_URL = "https://mainnet.rpc.buidlguidl.com";
 
 const scaffoldConfig = {
   // The networks on which your DApp is live

--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -2,7 +2,7 @@ import { wagmiConnectors } from "./wagmiConnectors";
 import { Chain, createClient, fallback, http } from "viem";
 import { hardhat, mainnet } from "viem/chains";
 import { createConfig } from "wagmi";
-import scaffoldConfig, { DEFAULT_ALCHEMY_API_KEY } from "~~/scaffold.config";
+import scaffoldConfig, { BG_MAINNET_RPC_URL } from "~~/scaffold.config";
 import { getAlchemyHttpUrl } from "~~/utils/scaffold-eth";
 
 const { targetNetworks } = scaffoldConfig;
@@ -21,9 +21,10 @@ export const wagmiConfig = createConfig({
 
     const alchemyHttpUrl = getAlchemyHttpUrl(chain.id);
     if (alchemyHttpUrl) {
-      const isUsingDefaultKey = scaffoldConfig.alchemyApiKey === DEFAULT_ALCHEMY_API_KEY;
-      // If using default Scaffold-ETH 2 API key, we prioritize the default RPC
-      rpcFallbacks = isUsingDefaultKey ? [http(), http(alchemyHttpUrl)] : [http(alchemyHttpUrl), http()];
+      const isMainnet = chain.id === 1;
+      rpcFallbacks = isMainnet
+        ? [http(BG_MAINNET_RPC_URL), http(alchemyHttpUrl), http()]
+        : [http(alchemyHttpUrl), http()];
     }
 
     return createClient({

--- a/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
+++ b/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
@@ -3,9 +3,12 @@ import { CurrencyAmount, Token } from "@uniswap/sdk-core";
 import { Pair, Route } from "@uniswap/v2-sdk";
 import { Address, createPublicClient, fallback, http, parseAbi } from "viem";
 import { mainnet } from "viem/chains";
+import { BG_MAINNET_RPC_URL } from "~~/scaffold.config";
 
 const alchemyHttpUrl = getAlchemyHttpUrl(mainnet.id);
-const rpcFallbacks = alchemyHttpUrl ? [http(alchemyHttpUrl), http()] : [http()];
+const rpcFallbacks = alchemyHttpUrl
+  ? [http(BG_MAINNET_RPC_URL), http(alchemyHttpUrl), http()]
+  : [http(BG_MAINNET_RPC_URL), http()];
 const publicClient = createPublicClient({
   chain: mainnet,
   transport: fallback(rpcFallbacks),


### PR DESCRIPTION
Since we have a BG RPC from https://client.buidlguidl.com/ I think it'll be a nice idea to have it as the default. Kept Alchemy as a fallback.

(If we see it is stable enough, we could consider adding it on SE-2)

Also created an Alchemy key for SRE + added to Vercel's env var: we were using the default one.