### PR TITLE
Remove public RPC

### DIFF
--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -22,9 +22,7 @@ export const wagmiConfig = createConfig({
     const alchemyHttpUrl = getAlchemyHttpUrl(chain.id);
     if (alchemyHttpUrl) {
       const isMainnet = chain.id === 1;
-      rpcFallbacks = isMainnet
-        ? [http(BG_MAINNET_RPC_URL), http(alchemyHttpUrl), http()]
-        : [http(alchemyHttpUrl), http()];
+      rpcFallbacks = isMainnet ? [http(BG_MAINNET_RPC_URL), http(alchemyHttpUrl)] : [http(alchemyHttpUrl)];
     }
 
     return createClient({

--- a/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
+++ b/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
@@ -6,9 +6,7 @@ import { mainnet } from "viem/chains";
 import { BG_MAINNET_RPC_URL } from "~~/scaffold.config";
 
 const alchemyHttpUrl = getAlchemyHttpUrl(mainnet.id);
-const rpcFallbacks = alchemyHttpUrl
-  ? [http(BG_MAINNET_RPC_URL), http(alchemyHttpUrl), http()]
-  : [http(BG_MAINNET_RPC_URL), http()];
+const rpcFallbacks = alchemyHttpUrl ? [http(BG_MAINNET_RPC_URL), http(alchemyHttpUrl)] : [http(BG_MAINNET_RPC_URL)];
 const publicClient = createPublicClient({
   chain: mainnet,
   transport: fallback(rpcFallbacks),


### PR DESCRIPTION
It seems that RPC requests run in parallel and it's slowly down things like ENS resolutions