### PR TITLE
Always siwe admin

### DIFF
--- a/packages/nextjs/app/_components/AdminSiwe.tsx
+++ b/packages/nextjs/app/_components/AdminSiwe.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { SignIn } from "../admin/_components/SignIn";
+import { Session } from "next-auth";
+import { useAccount } from "wagmi";
+import { useUser } from "~~/hooks/useUser";
+import { UserRole } from "~~/services/database/config/types";
+
+export default function AdminSiwe({ children, session }: { children: React.ReactNode; session: Session | null }) {
+  const { address: connectedAddress } = useAccount();
+  const { data: user } = useUser(connectedAddress);
+
+  if (user?.role === UserRole.ADMIN && !session?.user) {
+    return <SignIn />;
+  }
+
+  return children;
+}

--- a/packages/nextjs/app/admin/_components/SignIn.tsx
+++ b/packages/nextjs/app/admin/_components/SignIn.tsx
@@ -19,7 +19,7 @@ export const SignIn = () => {
   return (
     <div className="flex flex-col items-center px-4 py-10 sm:py-20">
       <h1 className="text-3xl text-center font-extrabold mb-1">Sign In</h1>
-      <p className="mb-6">You need to sign in to access the admin dashboard.</p>
+      <p className="mb-6">Please sign in with Ethereum to access the admin dashboard and app controls.</p>
       <button className="btn btn-primary" onClick={openConnectModal}>
         Sign in with Ethereum
       </button>

--- a/packages/nextjs/app/admin/layout.tsx
+++ b/packages/nextjs/app/admin/layout.tsx
@@ -1,5 +1,4 @@
 import { AccessDenied } from "./_components/AccessDenied";
-import { SignIn } from "./_components/SignIn";
 import { getServerSession } from "next-auth";
 import { UserRole } from "~~/services/database/config/types";
 import { authOptions } from "~~/utils/auth";
@@ -7,11 +6,7 @@ import { authOptions } from "~~/utils/auth";
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions);
 
-  if (!session?.user) {
-    return <SignIn />;
-  }
-
-  if (session.user.role !== UserRole.ADMIN) {
+  if (session?.user.role !== UserRole.ADMIN) {
     return <AccessDenied />;
   }
 

--- a/packages/nextjs/app/builders/[address]/_components/UserProfileCard.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/UserProfileCard.tsx
@@ -2,19 +2,15 @@
 
 import { UserLocation } from "./UserLocation";
 import { UserSocials } from "./UserSocials";
-import { useAccount } from "wagmi";
 import EditIcon from "~~/app/_assets/icons/EditIcon";
 import { UPDATE_USER_MODAL_ID, UpdateUserModal } from "~~/app/_components/UpdateUserModal";
 import { PunkBlockie } from "~~/components/PunkBlockie";
 import { Address } from "~~/components/scaffold-eth/Address/Address";
-import { useUser } from "~~/hooks/useUser";
-import { UserRole } from "~~/services/database/config/types";
+import { useAuthSession } from "~~/hooks/useAuthSession";
 import { UserByAddress } from "~~/services/database/repositories/users";
 
 export const UserProfileCard = ({ user, address }: { user: NonNullable<UserByAddress>; address: string }) => {
-  const { address: connectedAddress } = useAccount();
-  const { data: connectedUser } = useUser(connectedAddress);
-  const isAdmin = connectedUser?.role === UserRole.ADMIN;
+  const { isAdmin } = useAuthSession();
 
   return (
     <div className="bg-base-100 rounded-xl p-6 shadow-lg">

--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -1,9 +1,12 @@
 import { Space_Grotesk } from "next/font/google";
+import AdminSiwe from "./_components/AdminSiwe";
 import "@rainbow-me/rainbowkit/styles.css";
+import { getServerSession } from "next-auth";
 import PlausibleProvider from "next-plausible";
 import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithProviders";
 import { ThemeProvider } from "~~/components/ThemeProvider";
 import "~~/styles/globals.css";
+import { authOptions } from "~~/utils/auth";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
 const spaceGrotesk = Space_Grotesk({
@@ -16,7 +19,8 @@ export const metadata = getMetadata({
   description: "Learn how to build on Ethereum; the superpowers and the gotchas.",
 });
 
-const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
+const ScaffoldEthApp = async ({ children }: { children: React.ReactNode }) => {
+  const session = await getServerSession(authOptions);
   return (
     <html suppressHydrationWarning className={spaceGrotesk.className}>
       <head>
@@ -24,7 +28,9 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
       </head>
       <body>
         <ThemeProvider enableSystem>
-          <ScaffoldEthAppWithProviders>{children}</ScaffoldEthAppWithProviders>
+          <ScaffoldEthAppWithProviders>
+            <AdminSiwe session={session}>{children}</AdminSiwe>
+          </ScaffoldEthAppWithProviders>
         </ThemeProvider>
       </body>
     </html>

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
 import { RainbowKitProvider, darkTheme, lightTheme } from "@rainbow-me/rainbowkit";
 import { GetSiweMessageOptions, RainbowKitSiweNextAuthProvider } from "@rainbow-me/rainbowkit-siwe-next-auth";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -9,11 +8,13 @@ import { SessionProvider } from "next-auth/react";
 import { AppProgressBar as ProgressBar } from "next-nprogress-bar";
 import { useTheme } from "next-themes";
 import { Toaster } from "react-hot-toast";
-import { WagmiProvider } from "wagmi";
+import { WagmiProvider, useAccount } from "wagmi";
 import { Footer } from "~~/components/Footer";
 import { Header } from "~~/components/Header";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { useInitializeNativeCurrencyPrice } from "~~/hooks/scaffold-eth";
+import { useUser } from "~~/hooks/useUser";
+import { UserRole } from "~~/services/database/config/types";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
@@ -43,10 +44,21 @@ const getSiweMessageOptions: GetSiweMessageOptions = () => ({
   statement: "Sign in to SpeedRunEthereum",
 });
 
+const RainbowKitSiweProvider = ({ children }: { children: React.ReactNode }) => {
+  const { address: connectedAddress } = useAccount();
+  const { data: user } = useUser(connectedAddress);
+  const isRoleAdmin = user?.role === UserRole.ADMIN;
+
+  return (
+    <RainbowKitSiweNextAuthProvider enabled={isRoleAdmin} getSiweMessageOptions={getSiweMessageOptions}>
+      {children}
+    </RainbowKitSiweNextAuthProvider>
+  );
+};
+
 export const ScaffoldEthAppWithProviders = ({ children }: { children: React.ReactNode }) => {
   const { resolvedTheme } = useTheme();
   const isDarkMode = resolvedTheme === "dark";
-  const pathname = usePathname();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -58,17 +70,14 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
       <SessionProvider>
         <QueryClientProvider client={queryClient}>
           <ProgressBar height="3px" color="#2299dd" />
-          <RainbowKitSiweNextAuthProvider
-            enabled={pathname.startsWith("/admin")}
-            getSiweMessageOptions={getSiweMessageOptions}
-          >
+          <RainbowKitSiweProvider>
             <RainbowKitProvider
               avatar={BlockieAvatar}
               theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
             >
               <ScaffoldEthApp>{children}</ScaffoldEthApp>
             </RainbowKitProvider>
-          </RainbowKitSiweNextAuthProvider>
+          </RainbowKitSiweProvider>
         </QueryClientProvider>
       </SessionProvider>
     </WagmiProvider>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
@@ -14,7 +14,6 @@ import RegisterUser from "~~/app/_components/RegisterUser";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { useAuthSession } from "~~/hooks/useAuthSession";
 import { useUser } from "~~/hooks/useUser";
-import { UserRole } from "~~/services/database/config/types";
 import { getBlockExplorerAddressLink } from "~~/utils/scaffold-eth";
 
 /**
@@ -25,8 +24,7 @@ export const RainbowKitCustomConnectButton = () => {
   const { address: connectedAddress } = useAccount();
   const { data: user, isLoading: isLoadingUser } = useUser(connectedAddress);
   const { disconnect } = useDisconnect();
-  const { userAddress: sessionUserAddress } = useAuthSession();
-  const isAdmin = user?.role === UserRole.ADMIN;
+  const { isAdmin, userAddress: sessionUserAddress } = useAuthSession();
 
   useEffect(() => {
     if (sessionUserAddress && connectedAddress && connectedAddress !== sessionUserAddress) {


### PR DESCRIPTION
Reasons for the changes
- people can use impersonator so they can see content which relies just on `user.role === UserRole.Admin`
- it almost doesnt make sense to login as an admin without having access to admin functionality

Changed siwe behavior, so
1. User logs in. If he has Admin role then he requested for siwe. If user is not the admin, behavior will be the same.
2. I removed sign in for `/admin/**` pages. So since admins always do siwe, pages just accessible. For other users - access denied
3. All client behavior except [1] now depends on `isAdmin` from `useAuthSession`. 

Also, if someone will try to use impersonator with admin address
- because of [1] he will not even pass Sign in page. And since that page is always shown for admin he will not see other pages too
- even if we disable [1], because of [3] all the admin features will be disabled until siwe which is not possible with impersonator

---
notes:
- PR to `admin-menu` branch ( #166 )
- first commit changes siwe behavior, second commit adds changes to use `isAdmin`  from `useAuthSession`