### PR TITLE
Disallow /builds/ in robots.txt to block crawlers from build pages

### DIFF
--- a/packages/nextjs/public/robots.txt
+++ b/packages/nextjs/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Disallow: /builders/
+Disallow: /builds/
 Allow: /
 Sitemap: https://speedrunethereum.com/sitemap.xml


### PR DESCRIPTION
Builders pages are currently disallowed (it's where build pages are currently linked) and we have no /builds page yet, but adding it to robots just in case.

This way we'll also be ready for whenever we open the /builds page.