### PR TITLE
make all GET routes dynamic

### DIFF
--- a/packages/nextjs/app/api/activities/route.ts
+++ b/packages/nextjs/app/api/activities/route.ts
@@ -3,6 +3,8 @@ import { ActivityType } from "~~/services/api/activities";
 import { getActivities } from "~~/services/database/repositories/activities";
 import { isAdminSession } from "~~/utils/auth";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   const isAdmin = await isAdminSession();
   if (!isAdmin) {

--- a/packages/nextjs/app/api/batches/sorted/route.ts
+++ b/packages/nextjs/app/api/batches/sorted/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSortedBatches } from "~~/services/database/repositories/batches";
 import { isAdminSession } from "~~/utils/auth";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   try {
     const isAdmin = await isAdminSession();

--- a/packages/nextjs/app/api/og/route.tsx
+++ b/packages/nextjs/app/api/og/route.tsx
@@ -10,6 +10,8 @@ import {
 } from "~~/services/database/repositories/userChallenges";
 import { getEnsOrAddress, publicClient } from "~~/utils/ens-or-address";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);

--- a/packages/nextjs/app/api/users/in-batches/route.ts
+++ b/packages/nextjs/app/api/users/in-batches/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest } from "next/server";
 import { getSortedBatchBuilders } from "~~/services/database/repositories/users";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;

--- a/packages/nextjs/app/api/users/sorted/route.ts
+++ b/packages/nextjs/app/api/users/sorted/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest } from "next/server";
 import { getSortedUsersWithChallengesInfo } from "~~/services/database/repositories/users";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;


### PR DESCRIPTION
### Description: 

Actually all of this were actually being rendered as dynamic because we were using request object. And nextjs was automatically converting them to be dynamic (GET routes are static by default in Next 14 but here next was converting them automatically) 

[![Screenshot 2025-05-21 at 3 23 50 PM](https://github.com/user-attachments/assets/41da02e1-f429-4baa-814f-0d0d75af581a)](https://nextjs.org/docs/messages/dynamic-server-error)
