### PR TITLE
Ens with refresh button

### DIFF
--- a/packages/nextjs/app/api/users/[address]/update-ens/route.ts
+++ b/packages/nextjs/app/api/users/[address]/update-ens/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { isUserAdmin, updateUser } from "~~/services/database/repositories/users";
+import { isValidEIP712UpdateEnsSignature } from "~~/services/eip712/ens";
+import { publicClient } from "~~/utils/ens-or-address";
+
+type UpdateEnsPayload = {
+  address: string;
+  signature: `0x${string}`;
+};
+
+export async function PUT(req: Request, { params }: { params: { address: string } }) {
+  try {
+    const { address, signature } = (await req.json()) as UpdateEnsPayload;
+
+    if (!address || !signature) {
+      return NextResponse.json({ error: "Address and signature are required" }, { status: 400 });
+    }
+
+    const isAdmin = await isUserAdmin(address);
+    const addressToUpdateEns = params.address.toLowerCase();
+
+    if (address.toLowerCase() !== addressToUpdateEns.toLowerCase() && !isAdmin) {
+      return NextResponse.json({ error: "Address mismatch" }, { status: 400 });
+    }
+
+    const isValidSignature = await isValidEIP712UpdateEnsSignature({ address, signature });
+
+    if (!isValidSignature) {
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
+
+    try {
+      const ensName = await publicClient.getEnsName({ address: addressToUpdateEns });
+
+      if (!ensName) {
+        return NextResponse.json({ error: "No ENS name found for this address" }, { status: 400 });
+      }
+
+      const user = await updateUser(addressToUpdateEns, { ens: ensName });
+
+      return NextResponse.json({ user }, { status: 200 });
+    } catch (error) {
+      console.error(`Error getting ENS name for user ${address}:`, error);
+      return NextResponse.json({ error: "Failed to resolve ENS name" }, { status: 500 });
+    }
+  } catch (error) {
+    console.error("Error during ENS update:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/packages/nextjs/app/builders/[address]/_components/RefreshEnsButton.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/RefreshEnsButton.tsx
@@ -1,0 +1,19 @@
+import { useAccount } from "wagmi";
+import { useUpdateEns } from "~~/hooks/useUpdateEns";
+import { UserByAddress } from "~~/services/database/repositories/users";
+
+export const RefreshEnsButton = ({ user }: { user: NonNullable<UserByAddress> }) => {
+  const { address } = useAccount();
+  const { handleUpdateEns, isUpdatingEns } = useUpdateEns();
+  const isProfileOwner = address?.toLowerCase() === user.userAddress.toLowerCase();
+
+  if (!isProfileOwner) {
+    return null;
+  }
+
+  return (
+    <button className="btn btn-xs btn-outline w-full" onClick={handleUpdateEns} disabled={isUpdatingEns}>
+      {isUpdatingEns ? <span className="loading loading-spinner loading-xs"></span> : "Refresh ENS"}
+    </button>
+  );
+};

--- a/packages/nextjs/app/builders/[address]/_components/UserProfileCard.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/UserProfileCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { RefreshEnsButton } from "./RefreshEnsButton";
 import { UserLocation } from "./UserLocation";
 import { UserSocials } from "./UserSocials";
 import EditIcon from "~~/app/_assets/icons/EditIcon";
@@ -45,6 +46,8 @@ export const UserProfileCard = ({ user, batch }: { user: NonNullable<UserByAddre
           )}
 
           <hr className="w-full border-base-200 mb-2" />
+          <div className="text-sm text-neutral">ENS: {user.ens}</div>
+          <RefreshEnsButton user={user} />
           <UserLocation user={user} />
           <UserSocials user={user} />
           <div className="text-sm text-neutral">

--- a/packages/nextjs/hooks/useUpdateEns.ts
+++ b/packages/nextjs/hooks/useUpdateEns.ts
@@ -1,0 +1,60 @@
+import { useRouter } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAccount, useSignTypedData } from "wagmi";
+import { EIP_712_TYPED_DATA__UPDATE_ENS } from "~~/services/eip712/ens";
+import { notification } from "~~/utils/scaffold-eth";
+
+export function useUpdateEns() {
+  const { address } = useAccount();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { signTypedDataAsync } = useSignTypedData();
+
+  const { mutate: updateEns, isPending: isUpdatingEns } = useMutation({
+    mutationFn: async () => {
+      if (!address) throw new Error("Wallet not connected");
+
+      const signature = await signTypedDataAsync(EIP_712_TYPED_DATA__UPDATE_ENS);
+
+      const response = await fetch(`/api/users/${address}/update-ens`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ address, signature }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || "Failed to update ENS");
+      }
+
+      return response.json();
+    },
+    onSuccess: user => {
+      queryClient.setQueryData(["user", address], user);
+      router.refresh();
+      notification.success("ENS updated successfully!");
+    },
+    onError: (error: Error) => {
+      console.error("ENS update error:", error);
+      notification.error(error.message || "Failed to update ENS. Please try again.");
+    },
+  });
+
+  const handleUpdateEns = async () => {
+    if (!address) return;
+
+    try {
+      updateEns();
+    } catch (error) {
+      console.error("Error during ENS update:", error);
+      notification.error("Failed to update ENS. Please try again.");
+    }
+  };
+
+  return {
+    handleUpdateEns,
+    isUpdatingEns,
+  };
+}

--- a/packages/nextjs/services/eip712/ens.ts
+++ b/packages/nextjs/services/eip712/ens.ts
@@ -1,0 +1,26 @@
+import { EIP_712_DOMAIN, isValidEip712Signature } from "./common";
+
+export const EIP_712_TYPED_DATA__UPDATE_ENS = {
+  domain: EIP_712_DOMAIN,
+  types: {
+    Message: [
+      { name: "action", type: "string" },
+      { name: "description", type: "string" },
+    ],
+  },
+  primaryType: "Message",
+  message: {
+    action: "Update ENS",
+    description: "I would like to update my ENS name in speedrunethereum.com signing this offchain message",
+  },
+} as const;
+
+export const isValidEIP712UpdateEnsSignature = async ({
+  address,
+  signature,
+}: {
+  address: string;
+  signature: `0x${string}`;
+}) => {
+  return await isValidEip712Signature({ typedData: { ...EIP_712_TYPED_DATA__UPDATE_ENS, signature }, address });
+};


### PR DESCRIPTION
From https://github.com/BuidlGuidl/SpeedRunEthereum-v2/issues/45#issue-2914598028

> c. Have a "refresh" button in the user profile, so they can click it and we'll fetch it and cache it.
> c might be good (it's the most efficient at least haha), especially if we have the ENS stuff as a side quest (get your ENS! Read this article on what ENS is and how to get One... etc)

Possible implementation of refresh ENS button. But it's very weird to click to refresh ENS when you already have that ENS in some places on the page.
https://github.com/user-attachments/assets/8673cf56-a746-4b4b-98fd-1dfa228d0eda

If user created ENS right now and it's not yet resolved on ENS side then there will be no ENS on the page, but button also most likely won't work

