### PR TITLE
Auto update ens when connected

### DIFF
--- a/packages/nextjs/app/api/users/[address]/update-ens/route.ts
+++ b/packages/nextjs/app/api/users/[address]/update-ens/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { updateUser } from "~~/services/database/repositories/users";
+import { publicClient } from "~~/utils/ens-or-address";
+
+export async function PUT(req: Request, { params }: { params: { address: string } }) {
+  try {
+    const address = params.address.toLowerCase();
+
+    try {
+      const ensName = await publicClient.getEnsName({ address });
+
+      if (!ensName) {
+        return NextResponse.json({ error: "No ENS name found for this address" }, { status: 400 });
+      }
+
+      const user = await updateUser(address, { ens: ensName });
+
+      return NextResponse.json({ user }, { status: 200 });
+    } catch (error) {
+      console.error(`Error getting ENS name for user ${address}:`, error);
+      return NextResponse.json({ error: "Failed to resolve ENS name" }, { status: 500 });
+    }
+  } catch (error) {
+    console.error("Error during ENS update:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -4,8 +4,9 @@ import React, { useMemo } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Logo from "./Logo";
-import { useAccount } from "wagmi";
+import { useAccount, useEnsName } from "wagmi";
 import { RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
+import { useUpdateEns } from "~~/hooks/useUpdateEns";
 import { useUser } from "~~/hooks/useUser";
 import { UserRole } from "~~/services/database/config/types";
 import { UserByAddress } from "~~/services/database/repositories/users";
@@ -93,6 +94,12 @@ export const Header = () => {
 
   const { address: connectedAddress } = useAccount();
   const { data: user } = useUser(connectedAddress);
+  const { data: ens, isLoading: isEnsLoading } = useEnsName({
+    address: connectedAddress,
+    query: { enabled: Boolean(user) },
+  });
+  const cachedEns = user?.ens ?? null;
+  useUpdateEns({ address: connectedAddress, enabled: Boolean(user) && !isEnsLoading && cachedEns !== ens });
 
   return (
     <div className="sticky lg:static top-0 navbar bg-base-300 min-h-0 flex-shrink-0 justify-between z-20 px-0 sm:px-2">

--- a/packages/nextjs/hooks/useUpdateEns.ts
+++ b/packages/nextjs/hooks/useUpdateEns.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { notification } from "~~/utils/scaffold-eth";
+
+export function useUpdateEns({ address, enabled }: { address?: string; enabled: boolean }) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const { mutate: updateEns, isPending: isUpdatingEns } = useMutation({
+    mutationFn: async () => {
+      const response = await fetch(`/api/users/${address}/update-ens`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || "Failed to update ENS");
+      }
+
+      return response.json();
+    },
+    onSuccess: user => {
+      queryClient.setQueryData(["user", address], user);
+      router.refresh();
+      notification.success("ENS updated successfully!");
+    },
+    onError: (error: Error) => {
+      console.error("ENS update error:", error);
+    },
+  });
+
+  useEffect(() => {
+    if (enabled) {
+      try {
+        updateEns();
+      } catch (error) {
+        console.error("Error during ENS update:", error);
+        notification.error("Failed to update ENS. Please try again.");
+      }
+    }
+  }, [enabled, updateEns, address]);
+
+  return {
+    isUpdatingEns,
+  };
+}


### PR DESCRIPTION
Auto update ens when user.ens in db is different from the one from wagmi's `useEnsName`

<details><summary>Video</summary>
<p>


https://github.com/user-attachments/assets/d1f94310-3da4-49bf-a8ca-1b030a110b88



</p>
</details> 

Pros:
- works right after ens is resolved on ens side

Cons:
- works only for connected user. Other Ens addresses from the app won't be checked and cached