### PR TITLE
search on builders page

### DIFF
--- a/packages/nextjs/app/api/users/sorted/route.ts
+++ b/packages/nextjs/app/api/users/sorted/route.ts
@@ -9,8 +9,9 @@ export async function GET(request: NextRequest) {
     const start = parseInt(searchParams.get("start") ?? "0");
     const size = parseInt(searchParams.get("size") ?? "0");
     const sorting = JSON.parse(searchParams.get("sorting") ?? "[]");
+    const filter = searchParams.get("filter");
 
-    const data = await getSortedUsersWithChallengesInfo(start, size, sorting);
+    const data = await getSortedUsersWithChallengesInfo(start, size, sorting, filter || "");
 
     return Response.json(data);
   } catch (error) {

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -1,22 +1,42 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
+import { useDebounceValue } from "usehooks-ts";
+import SearchIcon from "~~/app/_assets/icons/SearchIcon";
 import { CopyValueToClipboard } from "~~/components/CopyValueToClipboard";
 import { DateWithTooltip } from "~~/components/DateWithTooltip";
 import InfiniteTable from "~~/components/InfiniteTable";
-import { Address } from "~~/components/scaffold-eth";
+import { Address, InputBase } from "~~/components/scaffold-eth";
 import { getSortedUsersWithChallenges } from "~~/services/api/users";
 import { UserWithChallengesData } from "~~/services/database/repositories/users";
 import { getUserSocialsList } from "~~/utils/socials";
 
 export default function BuildersPage() {
+  const [filter, setFilter] = useState("");
+  const [debouncedFilter] = useDebounceValue(filter, 500);
+
   const { data: builders, isLoading } = useQuery({
     queryKey: ["builders-count"],
     queryFn: () => getSortedUsersWithChallenges({ start: 0, size: 0, sorting: [] }),
   });
+
+  const { data: filteredBuilders, isLoading: isFilteredLoading } = useQuery({
+    queryKey: ["builders-filtered", debouncedFilter],
+    queryFn: () =>
+      getSortedUsersWithChallenges({
+        start: 0,
+        size: 1,
+        sorting: [],
+        filter: debouncedFilter.length >= 3 ? debouncedFilter : "",
+      }),
+    enabled: debouncedFilter.length >= 3,
+  });
+
+  const tableQueryKey = useMemo(() => ["users", debouncedFilter], [debouncedFilter]);
+  const tableInitialSorting = useMemo(() => [{ id: "lastActivity", desc: true }], []);
 
   const columns = useMemo<ColumnDef<UserWithChallengesData>[]>(
     () => [
@@ -81,6 +101,8 @@ export default function BuildersPage() {
     [],
   );
 
+  const showNoResults = debouncedFilter.length >= 3 && !isFilteredLoading && filteredBuilders?.meta.totalRowCount === 0;
+
   return (
     <div className="mx-4 text-center">
       <h2 className="mt-10 mb-0 text-3xl">All Builders</h2>
@@ -99,12 +121,39 @@ export default function BuildersPage() {
           <span>{builders?.meta.totalRowCount ?? 0}</span>
         )}
       </div>
-      <InfiniteTable<UserWithChallengesData>
-        columns={columns}
-        queryKey={useMemo(() => ["users"], [])}
-        queryFn={getSortedUsersWithChallenges}
-        initialSorting={useMemo(() => [{ id: "lastActivity", desc: true }], [])}
-      />
+
+      <div className="flex items-center justify-center max-w-md mt-4 mb-8 mx-auto">
+        <InputBase
+          name="filter"
+          value={filter}
+          onChange={setFilter}
+          placeholder="Search by ENS name or socials (min 3 chars)"
+          suffix={<SearchIcon className="w-7 h-6 pr-2 fill-primary/60 self-center" />}
+        />
+      </div>
+
+      {showNoResults ? (
+        <div className="mt-8 text-center">
+          <div className="bg-base-100 p-8 rounded-lg text-neutral">
+            No builders found matching &quot;{debouncedFilter}&quot;. Try a different search term.
+          </div>
+        </div>
+      ) : (
+        <InfiniteTable<UserWithChallengesData>
+          columns={columns}
+          showLoadingSkeleton={isFilteredLoading}
+          queryKey={tableQueryKey}
+          queryFn={({ start, size, sorting }) =>
+            getSortedUsersWithChallenges({
+              start,
+              size,
+              sorting,
+              filter: debouncedFilter.length >= 3 ? debouncedFilter : "",
+            })
+          }
+          initialSorting={tableInitialSorting}
+        />
+      )}
     </div>
   );
 }

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -127,7 +127,7 @@ export default function BuildersPage() {
           name="filter"
           value={filter}
           onChange={setFilter}
-          placeholder="Search by ENS name or socials (min 3 chars)"
+          placeholder="Search by ENS or socials"
           suffix={<SearchIcon className="w-7 h-6 pr-2 fill-primary/60 self-center" />}
         />
       </div>

--- a/packages/nextjs/components/InfiniteTable.tsx
+++ b/packages/nextjs/components/InfiniteTable.tsx
@@ -31,7 +31,7 @@ type InfiniteTableProps<T> = {
   fetchSize?: number;
   rowHeightInPx?: number;
   initialSorting?: SortingState;
-  showLoadingSkeleton?: boolean;
+  emptyStateMessage?: string;
 };
 
 export default function InfiniteTable<T>({
@@ -41,7 +41,7 @@ export default function InfiniteTable<T>({
   fetchSize = DEFAULT_FETCH_SIZE,
   rowHeightInPx = DEFAULT_ROW_HEIGHT_IN_PX,
   initialSorting = [],
-  showLoadingSkeleton = false,
+  emptyStateMessage = "No data found",
 }: InfiniteTableProps<T>) {
   // we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -87,13 +87,13 @@ export default function InfiniteTable<T>({
 
   const tableColumns = useMemo(
     () =>
-      isLoading || showLoadingSkeleton
+      isLoading
         ? columns.map(column => ({
             ...column,
             cell: () => <div className="skeleton h-4 w-full bg-accent" />,
           }))
         : columns,
-    [isLoading, columns, showLoadingSkeleton],
+    [isLoading, columns],
   );
 
   const table = useReactTable({
@@ -134,6 +134,14 @@ export default function InfiniteTable<T>({
         : undefined,
     overscan: 5,
   });
+
+  if (!isLoading && totalDBRowCount === 0) {
+    return (
+      <div className="mt-8 text-center mx-auto max-w-3xl">
+        <div className="bg-base-100 p-8 rounded-lg text-neutral shadow-lg">{emptyStateMessage}</div>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/packages/nextjs/components/InfiniteTable.tsx
+++ b/packages/nextjs/components/InfiniteTable.tsx
@@ -31,6 +31,7 @@ type InfiniteTableProps<T> = {
   fetchSize?: number;
   rowHeightInPx?: number;
   initialSorting?: SortingState;
+  showLoadingSkeleton?: boolean;
 };
 
 export default function InfiniteTable<T>({
@@ -40,6 +41,7 @@ export default function InfiniteTable<T>({
   fetchSize = DEFAULT_FETCH_SIZE,
   rowHeightInPx = DEFAULT_ROW_HEIGHT_IN_PX,
   initialSorting = [],
+  showLoadingSkeleton = false,
 }: InfiniteTableProps<T>) {
   // we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -85,13 +87,13 @@ export default function InfiniteTable<T>({
 
   const tableColumns = useMemo(
     () =>
-      isLoading
+      isLoading || showLoadingSkeleton
         ? columns.map(column => ({
             ...column,
             cell: () => <div className="skeleton h-4 w-full bg-accent" />,
           }))
         : columns,
-    [isLoading, columns],
+    [isLoading, columns, showLoadingSkeleton],
   );
 
   const table = useReactTable({

--- a/packages/nextjs/services/api/users/index.ts
+++ b/packages/nextjs/services/api/users/index.ts
@@ -73,12 +73,16 @@ export const getSortedUsersWithChallenges = async ({
   start,
   size,
   sorting,
+  filter,
 }: {
   start: number;
   size: number;
   sorting: SortingState;
+  filter?: string;
 }) => {
-  const response = await fetch(`/api/users/sorted?start=${start}&size=${size}&sorting=${JSON.stringify(sorting)}`);
+  const response = await fetch(
+    `/api/users/sorted?start=${start}&size=${size}&sorting=${JSON.stringify(sorting)}&filter=${filter ?? ""}`,
+  );
 
   if (!response.ok) {
     throw new Error(`Failed to fetch sorted users: ${response.status} ${response.statusText}`);


### PR DESCRIPTION
### Description: 

As described in #183 it works similar: 

> - Search in the ens name (when #179 is ready!) + socials.
> - 3 chars minimum to start querying database
> - Debounce

> It can be added at the top of the page, below the Builder count. Just show a spinner in the table when the query is happening and show results or "no builders found" text.

Instead of showing spinner showing the similar UI as "Fetching data" but happy to update it to show spinner 🙌 For no data we show : 

<img width="900" alt="image" src="https://github.com/user-attachments/assets/4418322d-78a7-4c6f-9696-8b4d13292dd4" />



Fixes #183 
