### PR TITLE
Siwe indicator and siwe onclick

### DIFF
--- a/packages/nextjs/app/admin/siwe/page.tsx
+++ b/packages/nextjs/app/admin/siwe/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+export default function SIWEPage() {
+  const router = useRouter();
+  // To prevent double back navigation
+  const hasNavigated = useRef(false);
+
+  useEffect(() => {
+    if (!hasNavigated.current) {
+      hasNavigated.current = true;
+      router.back();
+    }
+  }, [router]);
+
+  return null;
+}

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
@@ -2,6 +2,7 @@
 
 // @refresh reset
 import { useEffect } from "react";
+import Link from "next/link";
 import { AddressInfoDropdown } from "./AddressInfoDropdown";
 import { AddressQRCodeModal } from "./AddressQRCodeModal";
 import { WrongNetworkDropdown } from "./WrongNetworkDropdown";
@@ -9,7 +10,7 @@ import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { signOut } from "next-auth/react";
 import { Address } from "viem";
 import { useAccount, useDisconnect } from "wagmi";
-import { XMarkIcon } from "@heroicons/react/24/outline";
+import { EyeIcon, EyeSlashIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import RegisterUser from "~~/app/_components/RegisterUser";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { useAuthSession } from "~~/hooks/useAuthSession";
@@ -27,6 +28,7 @@ export const RainbowKitCustomConnectButton = () => {
   const { disconnect } = useDisconnect();
   const { userAddress: sessionUserAddress } = useAuthSession();
   const isAdmin = user?.role === UserRole.ADMIN;
+  const { isAdmin: isAdminFromSession } = useAuthSession();
 
   useEffect(() => {
     if (sessionUserAddress && connectedAddress && connectedAddress !== sessionUserAddress) {
@@ -78,7 +80,16 @@ export const RainbowKitCustomConnectButton = () => {
           <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center">
             {isAdmin && (
               <div className="flex items-center gap-2">
-                <span className="rounded-full px-3 py-0.5 font-semibold bg-red-100 text-red-800">ADMIN</span>
+                <span className="rounded-full pl-2 pr-3 flex items-center gap-1 py-0.5 font-semibold bg-red-100 text-red-800">
+                  {isAdminFromSession ? (
+                    <EyeIcon className="w-4 h-4" />
+                  ) : (
+                    <Link href="/admin/siwe" className="btn btn-ghost p-0.5 !min-h-0 h-auto hover:bg-red-200">
+                      <EyeSlashIcon className="w-4 h-4" />{" "}
+                    </Link>
+                  )}{" "}
+                  ADMIN
+                </span>
               </div>
             )}
             <AddressInfoDropdown


### PR DESCRIPTION
- Siwe indicator (Eye/EyeSlash icons)
- If not signed in with eth admin can click on EyeSlash Icon, Sign in and then he will be redirected back to the page he was before siwe.

How it works:

<details><summary>Video</summary>
<p>


https://github.com/user-attachments/assets/63b00fe4-8c52-4b93-aec6-1c121f32c9ce


</p>
</details> 

Fixes #168 