### PR TITLE
Fix scroll loading on all builds page

### DIFF
--- a/packages/nextjs/app/builds/_components/AllBuilds.tsx
+++ b/packages/nextjs/app/builds/_components/AllBuilds.tsx
@@ -200,6 +200,7 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
                 <span>No builds found. Please try searching with different filters.</span>
               </div>
             )}
+            <div id="sentinel" className="h-1" />
           </div>
         </div>
       </div>

--- a/packages/nextjs/hooks/useAllBuildsInfiniteQuery.tsx
+++ b/packages/nextjs/hooks/useAllBuildsInfiniteQuery.tsx
@@ -44,16 +44,29 @@ export function useAllBuildsInfiniteQuery({
   const totalBuilds = data?.pages?.[0]?.meta?.totalRowCount ?? 0;
 
   useEffect(() => {
-    const onscroll = () => {
-      const scrolledTo = window.scrollY + window.innerHeight;
-      const isReachBottom = document.body.scrollHeight === scrolledTo;
-      if (isReachBottom && hasNextPage && !isFetching) {
-        fetchNextPage();
-      }
-    };
-    window.addEventListener("scroll", onscroll);
+    const observer = new IntersectionObserver(
+      entries => {
+        const target = entries[0];
+        if (target.isIntersecting && hasNextPage && !isFetching) {
+          fetchNextPage();
+        }
+      },
+      {
+        root: null, // viewport
+        threshold: 0.1, // trigger when at least 10% of the target is visible
+      },
+    );
+
+    // Add a sentinel element at the bottom of your content
+    const sentinel = document.querySelector("#sentinel");
+    if (sentinel) {
+      observer.observe(sentinel);
+    }
+
     return () => {
-      window.removeEventListener("scroll", onscroll);
+      if (sentinel) {
+        observer.unobserve(sentinel);
+      }
     };
   }, [fetchNextPage, hasNextPage, isFetching]);
 


### PR DESCRIPTION
Replace the old scroll detection with `IntersectionObserver` which is more modern and may be more reliant for scroll detection.