### PR TITLE
Create fetchOnchainData service + use waitUntil in user register route

### DIFF
--- a/packages/nextjs/app/api/users/register/route.ts
+++ b/packages/nextjs/app/api/users/register/route.ts
@@ -39,11 +39,11 @@ export async function POST(req: Request) {
     const user = await createUser(userToCreate);
 
     // Background processing
+    waitUntil(trackPlausibleEvent(PlausibleEvent.SIGNUP_SRE, {}, req));
+
     waitUntil(
       (async () => {
         try {
-          await trackPlausibleEvent(PlausibleEvent.SIGNUP_SRE, {}, req);
-
           const { ensData } = await fetchOnchainData(address);
 
           // Update user with ENS data if we have any

--- a/packages/nextjs/app/api/users/register/route.ts
+++ b/packages/nextjs/app/api/users/register/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { waitUntil } from "@vercel/functions";
 import { InferInsertModel } from "drizzle-orm";
 import { users } from "~~/services/database/config/schema";
-import { createUser, isUserRegistered } from "~~/services/database/repositories/users";
+import { createUser, isUserRegistered, updateUser } from "~~/services/database/repositories/users";
 import { isValidEIP712UserRegisterSignature } from "~~/services/eip712/register";
 import { PlausibleEvent, trackPlausibleEvent } from "~~/services/plausible";
 import { publicClient } from "~~/utils/short-address-and-ens";
@@ -36,31 +36,46 @@ export async function POST(req: Request) {
       userAddress: address,
     };
 
-    let ensName: string | null = null;
-    try {
-      ensName = await publicClient.getEnsName({ address });
-
-      if (ensName) {
-        userToCreate.ens = ensName;
-      }
-    } catch (error) {
-      console.error(`Error getting ENS name for user ${address}:`, error);
-    }
-
-    if (ensName) {
-      try {
-        const ensAvatar = await publicClient.getEnsAvatar({ name: ensName });
-        if (ensAvatar) {
-          userToCreate.ensAvatar = ensAvatar;
-        }
-      } catch (error) {
-        console.error(`Error getting ENS avatar for user ${address}:`, error);
-      }
-    }
-
     const user = await createUser(userToCreate);
 
-    waitUntil(trackPlausibleEvent(PlausibleEvent.SIGNUP_SRE, {}, req));
+    // Background processing
+    waitUntil(
+      (async () => {
+        try {
+          await trackPlausibleEvent(PlausibleEvent.SIGNUP_SRE, {}, req);
+
+          let ensName: string | null = null;
+          try {
+            ensName = await publicClient.getEnsName({ address });
+          } catch (error) {
+            console.error(`Error getting ENS name for user ${address}:`, error);
+          }
+
+          let ensAvatar: string | null = null;
+          if (ensName) {
+            try {
+              ensAvatar = await publicClient.getEnsAvatar({ name: ensName });
+            } catch (error) {
+              console.error(`Error getting ENS avatar for user ${address}:`, error);
+            }
+          }
+
+          // Update user with ENS data if we have any
+          if (ensName || ensAvatar) {
+            const updateData: { ens?: string; ensAvatar?: string } = {};
+            if (ensName) updateData.ens = ensName;
+            if (ensAvatar) updateData.ensAvatar = ensAvatar;
+
+            await updateUser(address, updateData);
+            console.log(
+              `ENS data updated for user ${address}: ${ensName ? `name: ${ensName}` : ""} ${ensAvatar ? `avatar: ${ensAvatar}` : ""}`,
+            );
+          }
+        } catch (error) {
+          console.error(`Error in background processing for user ${address}:`, error);
+        }
+      })(),
+    );
 
     return NextResponse.json({ user }, { status: 200 });
   } catch (error) {

--- a/packages/nextjs/app/api/users/register/route.ts
+++ b/packages/nextjs/app/api/users/register/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { waitUntil } from "@vercel/functions";
 import { InferInsertModel } from "drizzle-orm";
 import { users } from "~~/services/database/config/schema";
-import { createUser, isUserRegistered, updateUser } from "~~/services/database/repositories/users";
+import { UserUpdate, createUser, isUserRegistered, updateUser } from "~~/services/database/repositories/users";
 import { isValidEIP712UserRegisterSignature } from "~~/services/eip712/register";
 import { fetchOnchainData } from "~~/services/onchainData";
 import { PlausibleEvent, trackPlausibleEvent } from "~~/services/plausible";
@@ -48,7 +48,7 @@ export async function POST(req: Request) {
 
           // Update user with ENS data if we have any
           if (ensData.name || ensData.avatar) {
-            const updateData = {
+            const updateData: UserUpdate = {
               ens: ensData.name ?? undefined,
               ensAvatar: ensData.avatar ?? undefined,
             };

--- a/packages/nextjs/services/database/repositories/users.ts
+++ b/packages/nextjs/services/database/repositories/users.ts
@@ -234,6 +234,7 @@ export async function updateUser(
     batchId?: number;
     batchStatus?: BatchUserStatus;
     ens?: string;
+    ensAvatar?: string;
   },
 ) {
   const result = await db

--- a/packages/nextjs/services/database/repositories/users.ts
+++ b/packages/nextjs/services/database/repositories/users.ts
@@ -1,4 +1,4 @@
-import { BatchUserStatus, ReviewAction, UserRole } from "../config/types";
+import { ReviewAction, UserRole } from "../config/types";
 import { ColumnSort, SortingState } from "@tanstack/react-table";
 import { InferInsertModel, and, isNotNull, or } from "drizzle-orm";
 import { eq, ilike, sql } from "drizzle-orm";
@@ -227,16 +227,7 @@ export async function isUserAdmin(userAddress: string): Promise<boolean> {
   return user?.role === UserRole.ADMIN;
 }
 
-export async function updateUser(
-  userAddress: string,
-  data: {
-    role?: UserRole;
-    batchId?: number;
-    batchStatus?: BatchUserStatus;
-    ens?: string;
-    ensAvatar?: string;
-  },
-) {
+export async function updateUser(userAddress: string, data: Partial<UserInsert>) {
   const result = await db
     .update(users)
     .set({

--- a/packages/nextjs/services/database/repositories/users.ts
+++ b/packages/nextjs/services/database/repositories/users.ts
@@ -11,6 +11,7 @@ type PickSocials<T> = {
 };
 
 export type UserInsert = InferInsertModel<typeof users>;
+export type UserUpdate = Partial<Omit<UserInsert, "userAddress">>;
 export type UserByAddress = Awaited<ReturnType<typeof getUserByAddress>>;
 export type UserSocials = PickSocials<NonNullable<UserByAddress>>;
 export type UserWithChallengesData = Awaited<ReturnType<typeof getSortedUsersWithChallengesInfo>>["data"][0];
@@ -227,7 +228,7 @@ export async function isUserAdmin(userAddress: string): Promise<boolean> {
   return user?.role === UserRole.ADMIN;
 }
 
-export async function updateUser(userAddress: string, data: Partial<UserInsert>) {
+export async function updateUser(userAddress: string, data: UserUpdate) {
   const result = await db
     .update(users)
     .set({

--- a/packages/nextjs/services/onchainData/ens.ts
+++ b/packages/nextjs/services/onchainData/ens.ts
@@ -1,0 +1,27 @@
+import { publicClient } from "~~/utils/short-address-and-ens";
+
+export type EnsData = {
+  name: string | null;
+  avatar: string | null;
+};
+
+export async function fetchEnsData(address: string): Promise<EnsData> {
+  let name: string | null = null;
+  let avatar: string | null = null;
+
+  try {
+    name = await publicClient.getEnsName({ address });
+  } catch (error) {
+    console.error(`Error getting ENS name for ${address}:`, error);
+  }
+
+  if (name) {
+    try {
+      avatar = await publicClient.getEnsAvatar({ name });
+    } catch (error) {
+      console.error(`Error getting ENS avatar for ${address}:`, error);
+    }
+  }
+
+  return { name, avatar };
+}

--- a/packages/nextjs/services/onchainData/index.ts
+++ b/packages/nextjs/services/onchainData/index.ts
@@ -7,10 +7,10 @@ export type OnchainData = {
 };
 
 export async function fetchOnchainData(address: string): Promise<OnchainData> {
-  const ens = await fetchEnsData(address);
+  const ensData = await fetchEnsData(address);
 
   return {
     address,
-    ensData: ens,
+    ensData,
   };
 }

--- a/packages/nextjs/services/onchainData/index.ts
+++ b/packages/nextjs/services/onchainData/index.ts
@@ -1,0 +1,16 @@
+import type { EnsData } from "./ens";
+import { fetchEnsData } from "./ens";
+
+export type OnchainData = {
+  address: string;
+  ensData: EnsData;
+};
+
+export async function fetchOnchainData(address: string): Promise<OnchainData> {
+  const ens = await fetchEnsData(address);
+
+  return {
+    address,
+    ensData: ens,
+  };
+}

--- a/packages/nextjs/services/onchainData/index.ts
+++ b/packages/nextjs/services/onchainData/index.ts
@@ -2,7 +2,6 @@ import type { EnsData } from "./ens";
 import { fetchEnsData } from "./ens";
 
 export type OnchainData = {
-  address: string;
   ensData: EnsData;
 };
 
@@ -10,7 +9,6 @@ export async function fetchOnchainData(address: string): Promise<OnchainData> {
   const ensData = await fetchEnsData(address);
 
   return {
-    address,
     ensData,
   };
 }


### PR DESCRIPTION
Fixes #218 

1. Use `waitUntil` to fetch ENS data after user registers
2. Created an onchainData service (more context in https://github.com/BuidlGuidl/SpeedRunEthereum-v2/issues/218). It might be early optimization / a bit verbose... but I think it'll play nicely when we start adding more onchain fetchers services.