### PR TITLE
Track referrer

### DIFF
--- a/packages/nextjs/app/_components/RegisterUser.tsx
+++ b/packages/nextjs/app/_components/RegisterUser.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useLocalStorage } from "usehooks-ts";
 import { useAccount } from "wagmi";
 import { UserIcon } from "@heroicons/react/24/outline";
 import { PunkBlockie } from "~~/components/PunkBlockie";
@@ -10,6 +11,7 @@ export const RegisterUser = () => {
   const [showTooltip, setShowTooltip] = useState(true);
   const { handleRegister, isRegistering } = useUserRegister();
   const containerRef = useRef<HTMLDivElement>(null);
+  const [storedReferrer] = useLocalStorage<string | null>("originalReferrer", null);
 
   useEffect(() => {
     if (!showTooltip) return;
@@ -51,7 +53,7 @@ export const RegisterUser = () => {
           )}
           <button
             className="flex items-center justify-center py-1.5 lg:py-2 px-3 lg:px-4 border-2 border-primary rounded-full bg-base-300 hover:bg-base-200 transition-colors cursor-pointer mt-4 text-sm w-full"
-            onClick={handleRegister}
+            onClick={() => handleRegister(storedReferrer)}
             disabled={isRegistering}
           >
             {isRegistering ? (

--- a/packages/nextjs/app/_components/StartBuildingButton.tsx
+++ b/packages/nextjs/app/_components/StartBuildingButton.tsx
@@ -3,16 +3,13 @@
 import { useCallback } from "react";
 import Link from "next/link";
 import { usePlausible } from "next-plausible";
-import { useLocalStorage } from "usehooks-ts";
 
 export const StartBuildingButton = () => {
   const plausible = usePlausible();
-  const [storedReferrer] = useLocalStorage<string | null>("originalReferrer", null);
 
-  // TODO: test this later
   const handleCtaClick = useCallback(() => {
-    plausible("cta", { props: { referrer: storedReferrer || "" } });
-  }, [plausible, storedReferrer]);
+    plausible("cta");
+  }, [plausible]);
 
   return (
     <Link

--- a/packages/nextjs/app/_components/StartBuildingButton.tsx
+++ b/packages/nextjs/app/_components/StartBuildingButton.tsx
@@ -3,14 +3,16 @@
 import { useCallback } from "react";
 import Link from "next/link";
 import { usePlausible } from "next-plausible";
+import { useLocalStorage } from "usehooks-ts";
 
 export const StartBuildingButton = () => {
   const plausible = usePlausible();
+  const [storedReferrer] = useLocalStorage<string | null>("originalReferrer", null);
 
   // TODO: test this later
   const handleCtaClick = useCallback(() => {
-    plausible("cta");
-  }, [plausible]);
+    plausible("cta", { props: { referrer: storedReferrer || "" } });
+  }, [plausible, storedReferrer]);
 
   return (
     <Link

--- a/packages/nextjs/app/api/challenges/[challengeId]/submit/route.ts
+++ b/packages/nextjs/app/api/challenges/[challengeId]/submit/route.ts
@@ -69,7 +69,8 @@ export async function POST(req: NextRequest, { params }: { params: { challengeId
     waitUntil(
       (async () => {
         try {
-          await trackPlausibleEvent(PlausibleEvent.CHALLENGE_SUBMISSION, { challengeId }, req);
+          const referrer = user?.referrer || "";
+          await trackPlausibleEvent(PlausibleEvent.CHALLENGE_SUBMISSION, { challengeId, referrer }, req);
           const autoGraderChallengeId = challenge.sortOrder;
 
           const gradingResult = await submitToAutograder({

--- a/packages/nextjs/app/api/challenges/[challengeId]/submit/route.ts
+++ b/packages/nextjs/app/api/challenges/[challengeId]/submit/route.ts
@@ -70,7 +70,7 @@ export async function POST(req: NextRequest, { params }: { params: { challengeId
       (async () => {
         try {
           const referrer = user?.referrer || "";
-          await trackPlausibleEvent(PlausibleEvent.CHALLENGE_SUBMISSION, { challengeId, referrer }, req);
+          await trackPlausibleEvent(PlausibleEvent.CHALLENGE_SUBMISSION, { challengeId }, req, referrer);
           const autoGraderChallengeId = challenge.sortOrder;
 
           const gradingResult = await submitToAutograder({

--- a/packages/nextjs/app/api/users/join-batch/route.ts
+++ b/packages/nextjs/app/api/users/join-batch/route.ts
@@ -63,7 +63,8 @@ export async function POST(req: Request) {
       batchStatus: BatchUserStatus.CANDIDATE,
     });
 
-    waitUntil(trackPlausibleEvent(PlausibleEvent.JOIN_BATCH, {}, req));
+    const referrer = user?.referrer || "";
+    waitUntil(trackPlausibleEvent(PlausibleEvent.JOIN_BATCH, { referrer }, req));
 
     return NextResponse.json({ user: updatedUser }, { status: 200 });
   } catch (error) {

--- a/packages/nextjs/app/api/users/join-batch/route.ts
+++ b/packages/nextjs/app/api/users/join-batch/route.ts
@@ -64,7 +64,7 @@ export async function POST(req: Request) {
     });
 
     const referrer = user?.referrer || "";
-    waitUntil(trackPlausibleEvent(PlausibleEvent.JOIN_BATCH, { referrer }, req));
+    waitUntil(trackPlausibleEvent(PlausibleEvent.JOIN_BATCH, {}, req, referrer));
 
     return NextResponse.json({ user: updatedUser }, { status: 200 });
   } catch (error) {

--- a/packages/nextjs/app/api/users/register/route.ts
+++ b/packages/nextjs/app/api/users/register/route.ts
@@ -41,7 +41,7 @@ export async function POST(req: Request) {
     const user = await createUser(userToCreate);
 
     // Background processing
-    waitUntil(trackPlausibleEvent(PlausibleEvent.SIGNUP_SRE, { referrer: referrer ?? "" }, req));
+    waitUntil(trackPlausibleEvent(PlausibleEvent.SIGNUP_SRE, {}, req, referrer));
 
     waitUntil(
       (async () => {

--- a/packages/nextjs/app/api/users/register/route.ts
+++ b/packages/nextjs/app/api/users/register/route.ts
@@ -10,11 +10,12 @@ import { PlausibleEvent, trackPlausibleEvent } from "~~/services/plausible";
 type RegisterPayload = {
   address: string;
   signature: `0x${string}`;
+  referrer: string | null;
 };
 
 export async function POST(req: Request) {
   try {
-    const { address, signature } = (await req.json()) as RegisterPayload;
+    const { address, signature, referrer } = (await req.json()) as RegisterPayload;
 
     if (!address || !signature) {
       return NextResponse.json({ error: "Address and signature are required" }, { status: 400 });
@@ -34,12 +35,13 @@ export async function POST(req: Request) {
 
     const userToCreate: InferInsertModel<typeof users> = {
       userAddress: address,
+      referrer,
     };
 
     const user = await createUser(userToCreate);
 
     // Background processing
-    waitUntil(trackPlausibleEvent(PlausibleEvent.SIGNUP_SRE, {}, req));
+    waitUntil(trackPlausibleEvent(PlausibleEvent.SIGNUP_SRE, { referrer: referrer ?? "" }, req));
 
     waitUntil(
       (async () => {

--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Space_Grotesk } from "next/font/google";
 import "@rainbow-me/rainbowkit/styles.css";
 import PlausibleProvider from "next-plausible";
+import ReferrerTracker from "~~/components/ReferrerTracker";
 import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithProviders";
 import { ThemeProvider } from "~~/components/ThemeProvider";
 import "~~/styles/globals.css";
@@ -24,6 +25,7 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
       </head>
       <body>
         <ThemeProvider enableSystem>
+          <ReferrerTracker />
           <ScaffoldEthAppWithProviders>{children}</ScaffoldEthAppWithProviders>
         </ThemeProvider>
       </body>

--- a/packages/nextjs/app/start/_components/StartChallengesButton.tsx
+++ b/packages/nextjs/app/start/_components/StartChallengesButton.tsx
@@ -3,16 +3,13 @@
 import { useCallback } from "react";
 import Link from "next/link";
 import { usePlausible } from "next-plausible";
-import { useLocalStorage } from "usehooks-ts";
 
 export const StartChallengesButton = () => {
   const plausible = usePlausible();
-  const [storedReferrer] = useLocalStorage<string | null>("originalReferrer", null);
 
-  // TODO: test this later
   const handleCtaClick = useCallback(() => {
-    plausible("cta_from_start", { props: { referrer: storedReferrer || "" } });
-  }, [plausible, storedReferrer]);
+    plausible("cta_from_start");
+  }, [plausible]);
 
   return (
     <Link

--- a/packages/nextjs/app/start/_components/StartChallengesButton.tsx
+++ b/packages/nextjs/app/start/_components/StartChallengesButton.tsx
@@ -3,14 +3,16 @@
 import { useCallback } from "react";
 import Link from "next/link";
 import { usePlausible } from "next-plausible";
+import { useLocalStorage } from "usehooks-ts";
 
 export const StartChallengesButton = () => {
   const plausible = usePlausible();
+  const [storedReferrer] = useLocalStorage<string | null>("originalReferrer", null);
 
   // TODO: test this later
   const handleCtaClick = useCallback(() => {
-    plausible("cta_from_start");
-  }, [plausible]);
+    plausible("cta_from_start", { props: { referrer: storedReferrer || "" } });
+  }, [plausible, storedReferrer]);
 
   return (
     <Link

--- a/packages/nextjs/components/ReferrerTracker.tsx
+++ b/packages/nextjs/components/ReferrerTracker.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { useLocalStorage } from "usehooks-ts";
+
+// Store the original referer in local storage to track the source of the user
+const ReferrerTracker = () => {
+  const [storedReferrer, setStoredReferrer] = useLocalStorage<string | null>("originalReferrer", null);
+
+  useEffect(() => {
+    // Skip if already stored
+    if (storedReferrer) return;
+
+    // Delete: this is for testing purposes only
+    // e.g. http://localhost:3000/?mockReferrer=https://www.example.com
+    const urlParams = new URLSearchParams(window.location.search);
+    const mockReferrer = urlParams.get("mockReferrer");
+
+    const referrer = mockReferrer || document.referrer;
+    const currentDomain = window.location.hostname;
+
+    if (referrer && !referrer.includes(currentDomain)) {
+      setStoredReferrer(referrer);
+    }
+  }, [storedReferrer, setStoredReferrer]);
+
+  return null;
+};
+
+export default ReferrerTracker;

--- a/packages/nextjs/components/ReferrerTracker.tsx
+++ b/packages/nextjs/components/ReferrerTracker.tsx
@@ -11,12 +11,7 @@ const ReferrerTracker = () => {
     // Skip if already stored
     if (storedReferrer) return;
 
-    // Delete: this is for testing purposes only
-    // e.g. http://localhost:3000/?mockReferrer=https://www.example.com
-    const urlParams = new URLSearchParams(window.location.search);
-    const mockReferrer = urlParams.get("mockReferrer");
-
-    const referrer = mockReferrer || document.referrer;
+    const referrer = document.referrer;
     const currentDomain = window.location.hostname;
 
     if (referrer && !referrer.includes(currentDomain)) {

--- a/packages/nextjs/hooks/useUserRegister.ts
+++ b/packages/nextjs/hooks/useUserRegister.ts
@@ -21,12 +21,12 @@ export function useUserRegister() {
     },
   });
 
-  const handleRegister = async () => {
+  const handleRegister = async (referrer: string | null) => {
     if (!address) return;
 
     try {
       const signature = await signTypedDataAsync(EIP_712_TYPED_DATA__USER_REGISTER);
-      register({ address, signature });
+      register({ address, signature, referrer });
     } catch (error) {
       console.error("Error during signature:", error);
       notification.error("Failed to sign message. Please try again.");

--- a/packages/nextjs/services/api/users/index.ts
+++ b/packages/nextjs/services/api/users/index.ts
@@ -17,13 +17,21 @@ export async function fetchUser(address: string | undefined) {
   return data.user as UserByAddress;
 }
 
-export async function registerUser({ address, signature }: { address: string; signature: string }) {
+export async function registerUser({
+  address,
+  signature,
+  referrer,
+}: {
+  address: string;
+  signature: string;
+  referrer: string | null;
+}) {
   const response = await fetch("/api/users/register", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ address, signature }),
+    body: JSON.stringify({ address, signature, referrer }),
   });
 
   const data = await response.json();

--- a/packages/nextjs/services/database/config/schema.ts
+++ b/packages/nextjs/services/database/config/schema.ts
@@ -46,6 +46,7 @@ export const users = pgTable(
     location: varchar({ length: 255 }),
     batchId: integer().references(() => batches.id),
     batchStatus: batchUserStatusEnum(),
+    referrer: varchar({ length: 255 }),
   },
   table => [uniqueIndex("idUniqueIndex").on(lower(table.userAddress))],
 );

--- a/packages/nextjs/services/database/migrations/0007_unique_iron_monger.sql
+++ b/packages/nextjs/services/database/migrations/0007_unique_iron_monger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "referrer" varchar(255);

--- a/packages/nextjs/services/database/migrations/meta/0007_snapshot.json
+++ b/packages/nextjs/services/database/migrations/meta/0007_snapshot.json
@@ -1,0 +1,768 @@
+{
+  "id": "65d7ad30-d457-46b3-9b7f-88ea1a9dce8d",
+  "prevId": "c3f6597a-dd0f-4482-8e38-76947a91c2fd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status_enum",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_link": {
+          "name": "telegram_link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bg_subdomain": {
+          "name": "bg_subdomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.build_builders": {
+      "name": "build_builders",
+      "schema": "",
+      "columns": {
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "build_builder_user_idx": {
+          "name": "build_builder_user_idx",
+          "columns": [
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "build_builders_build_id_builds_id_fk": {
+          "name": "build_builders_build_id_builds_id_fk",
+          "tableFrom": "build_builders",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "build_builders_user_address_users_user_address_fk": {
+          "name": "build_builders_user_address_users_user_address_fk",
+          "tableFrom": "build_builders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_address"
+          ],
+          "columnsTo": [
+            "user_address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "build_builders_build_id_user_address_pk": {
+          "name": "build_builders_build_id_user_address_pk",
+          "columns": [
+            "build_id",
+            "user_address"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.build_likes": {
+      "name": "build_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked_at": {
+          "name": "liked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "build_like_unique_idx": {
+          "name": "build_like_unique_idx",
+          "columns": [
+            {
+              "expression": "build_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "build_likes_build_id_builds_id_fk": {
+          "name": "build_likes_build_id_builds_id_fk",
+          "tableFrom": "build_likes",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "build_likes_user_address_users_user_address_fk": {
+          "name": "build_likes_user_address_users_user_address_fk",
+          "tableFrom": "build_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_address"
+          ],
+          "columnsTo": [
+            "user_address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.builds": {
+      "name": "builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desc": {
+          "name": "desc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_type": {
+          "name": "build_type",
+          "type": "build_type_enum",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_category": {
+          "name": "build_category",
+          "type": "build_category_enum",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_url": {
+          "name": "demo_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_timestamp": {
+          "name": "submitted_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "build_type_idx": {
+          "name": "build_type_idx",
+          "columns": [
+            {
+              "expression": "build_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "build_category_idx": {
+          "name": "build_category_idx",
+          "columns": [
+            {
+              "expression": "build_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenge_name": {
+          "name": "challenge_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autograding": {
+          "name": "autograding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "preview_image": {
+          "name": "preview_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_link": {
+          "name": "external_link",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenges": {
+      "name": "user_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frontend_url": {
+          "name": "frontend_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_url": {
+          "name": "contract_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_comment": {
+          "name": "review_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "review_action": {
+          "name": "review_action",
+          "type": "review_action_enum",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_challenge_lookup_idx": {
+          "name": "user_challenge_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_challenge_review_idx": {
+          "name": "user_challenge_review_idx",
+          "columns": [
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenges_user_address_users_user_address_fk": {
+          "name": "user_challenges_user_address_users_user_address_fk",
+          "tableFrom": "user_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_address"
+          ],
+          "columnsTo": [
+            "user_address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenges_challenge_id_challenges_id_fk": {
+          "name": "user_challenges_challenge_id_challenges_id_fk",
+          "tableFrom": "user_challenges",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role_enum",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USER'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ens": {
+          "name": "ens",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ens_avatar": {
+          "name": "ens_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_telegram": {
+          "name": "social_telegram",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_x": {
+          "name": "social_x",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_github": {
+          "name": "social_github",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_instagram": {
+          "name": "social_instagram",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_discord": {
+          "name": "social_discord",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_email": {
+          "name": "social_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_status": {
+          "name": "batch_status",
+          "type": "batch_user_status_enum",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idUniqueIndex": {
+          "name": "idUniqueIndex",
+          "columns": [
+            {
+              "expression": "lower(\"user_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_batch_id_batches_id_fk": {
+          "name": "users_batch_id_batches_id_fk",
+          "tableFrom": "users",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.batch_status_enum": {
+      "name": "batch_status_enum",
+      "schema": "public",
+      "values": [
+        "closed",
+        "open"
+      ]
+    },
+    "public.batch_user_status_enum": {
+      "name": "batch_user_status_enum",
+      "schema": "public",
+      "values": [
+        "graduate",
+        "candidate"
+      ]
+    },
+    "public.build_category_enum": {
+      "name": "build_category_enum",
+      "schema": "public",
+      "values": [
+        "DeFi",
+        "Gaming",
+        "NFTs",
+        "Social",
+        "DAOs & Governance",
+        "Dev Tooling",
+        "Identity & Reputation",
+        "RWA & Supply Chain",
+        "AI Agents",
+        "Prediction Markets"
+      ]
+    },
+    "public.build_type_enum": {
+      "name": "build_type_enum",
+      "schema": "public",
+      "values": [
+        "Dapp",
+        "Infrastructure",
+        "Challenge submission",
+        "Content",
+        "Design",
+        "Other"
+      ]
+    },
+    "public.review_action_enum": {
+      "name": "review_action_enum",
+      "schema": "public",
+      "values": [
+        "REJECTED",
+        "ACCEPTED",
+        "SUBMITTED"
+      ]
+    },
+    "public.user_role_enum": {
+      "name": "user_role_enum",
+      "schema": "public",
+      "values": [
+        "USER",
+        "BUILDER",
+        "ADMIN"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/nextjs/services/database/migrations/meta/_journal.json
+++ b/packages/nextjs/services/database/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1749656686202,
       "tag": "0006_normal_maelstrom",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1751993122948,
+      "tag": "0007_unique_iron_monger",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/nextjs/services/plausible.ts
+++ b/packages/nextjs/services/plausible.ts
@@ -10,11 +10,13 @@ export async function trackPlausibleEvent(
   eventName: PlausibleEvent,
   props?: Record<string, string | number | boolean>,
   request?: Request,
+  referrer?: string | null,
 ) {
   const payload = {
     domain: "speedrunethereum.com",
     name: eventName,
     url: `https://speedrunethereum.com`,
+    referrer: referrer || "",
     props,
   };
 


### PR DESCRIPTION
As #209 says, the original referrer information was being lost when users returned to the site after a period of inactivity, as Plausible only tracks the referrer at the start of a session (lost after 30 min). This resulted in new sessions being marked as "Direct" unless the user came from another site again. 

**This is a first iteration / starting point (I haven't tested properly) @Pabl0cks will check later and we can keep discussing tomorrow.**

This PR tries to solve the issue:
- store the referrer in local storage when the user visits from another place
- store it in database (when registering)
- use the referrer when sending a request to PLausible (in backend and frontend). https://plausible.io/docs/events-api. 

Also tagging @technophile-04 so he can double check I'm not doing anything weird


Fixes #209 