### PR TITLE
Plausible: referrer as a custom prop

### DIFF
--- a/packages/nextjs/app/api/challenges/[challengeId]/submit/route.ts
+++ b/packages/nextjs/app/api/challenges/[challengeId]/submit/route.ts
@@ -69,8 +69,12 @@ export async function POST(req: NextRequest, { params }: { params: { challengeId
     waitUntil(
       (async () => {
         try {
-          const referrer = user?.referrer || "";
-          await trackPlausibleEvent(PlausibleEvent.CHALLENGE_SUBMISSION, { challengeId }, req, referrer);
+          const referrer = user?.referrer || undefined;
+          await trackPlausibleEvent(
+            PlausibleEvent.CHALLENGE_SUBMISSION,
+            { challengeId, originalReferrer: referrer },
+            req,
+          );
           const autoGraderChallengeId = challenge.sortOrder;
 
           const gradingResult = await submitToAutograder({

--- a/packages/nextjs/app/api/users/join-batch/route.ts
+++ b/packages/nextjs/app/api/users/join-batch/route.ts
@@ -63,8 +63,8 @@ export async function POST(req: Request) {
       batchStatus: BatchUserStatus.CANDIDATE,
     });
 
-    const referrer = user?.referrer || "";
-    waitUntil(trackPlausibleEvent(PlausibleEvent.JOIN_BATCH, {}, req, referrer));
+    const referrer = user?.referrer || undefined;
+    waitUntil(trackPlausibleEvent(PlausibleEvent.JOIN_BATCH, { originalReferrer: referrer }, req));
 
     return NextResponse.json({ user: updatedUser }, { status: 200 });
   } catch (error) {

--- a/packages/nextjs/app/api/users/register/route.ts
+++ b/packages/nextjs/app/api/users/register/route.ts
@@ -41,7 +41,7 @@ export async function POST(req: Request) {
     const user = await createUser(userToCreate);
 
     // Background processing
-    waitUntil(trackPlausibleEvent(PlausibleEvent.SIGNUP_SRE, {}, req, referrer));
+    waitUntil(trackPlausibleEvent(PlausibleEvent.SIGNUP_SRE, { originalReferrer: referrer ?? undefined }, req));
 
     waitUntil(
       (async () => {

--- a/packages/nextjs/services/plausible.ts
+++ b/packages/nextjs/services/plausible.ts
@@ -8,15 +8,13 @@ const PLAUSIBLE_EVENT_ENDPOINT = "https://plausible.io/api/event";
 
 export async function trackPlausibleEvent(
   eventName: PlausibleEvent,
-  props?: Record<string, string | number | boolean>,
+  props?: Record<string, string | number | boolean | undefined>,
   request?: Request,
-  referrer?: string | null,
 ) {
   const payload = {
     domain: "speedrunethereum.com",
     name: eventName,
     url: `https://speedrunethereum.com`,
-    referrer: referrer || "",
     props,
   };
 


### PR DESCRIPTION
It seems that Referrer property is not working  (from the backend)

They have it here: https://plausible.io/docs/events-api

Our hypothesis: since we are forwarding the `User-Agent` and `X-Forwarded-For` in `trackPlausibleEvent`, Plausible is identifying that user with the session initiated from the front-end (with NO referrer). So plausible ignores our hardcoded referrer and just attaches the user to the already existing session.


I'd be nice to integrate properly (also thinking about future UTM stuff) at some point.... but for now, this PR adds a new `originalReferrer` custom prop, so at least we could filter by it (even if we won't see it in the "Top Source" panel).

