### PR TITLE
Add progress bar to grouped challenges

### DIFF
--- a/packages/nextjs/app/builders/[address]/_components/GroupedChallengeTitle.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/GroupedChallengeTitle.tsx
@@ -1,0 +1,31 @@
+import type { MappedChallenges } from "./GroupedChallenges";
+import { ReviewAction } from "~~/services/database/config/types";
+
+export function GroupedChallengeTitle({
+  title,
+  icon,
+  challenges,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  challenges: MappedChallenges[];
+}) {
+  const completed = challenges.filter(challenge => challenge.reviewAction === ReviewAction.ACCEPTED).length;
+  const total = challenges.length;
+  const progress = (completed / total) * 100;
+
+  return (
+    <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-4">
+      <div className="flex items-center gap-2">
+        {icon}
+        {title}
+      </div>
+      <div className="flex items-center gap-3 lg:ml-4">
+        <p className="m-0 text-xs">
+          {completed} / {total} completed
+        </p>
+        <progress className="progress progress-info w-40" value={progress} max="100"></progress>
+      </div>
+    </div>
+  );
+}

--- a/packages/nextjs/app/builders/[address]/_components/GroupedChallenges.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/GroupedChallenges.tsx
@@ -1,6 +1,7 @@
 import { ChallengeDetails } from "./ChallengeDetails";
 import { ChallengeDetailsStatus } from "./ChallengeDetailsStatus";
 import { ChallengeIconComputer, ChallengeIconRocket } from "./ChallengeGroupIcons";
+import { GroupedChallengeTitle } from "./GroupedChallengeTitle";
 import "./groupedChallenges.css";
 import { type Address } from "viem";
 import { ChallengeId, ReviewAction } from "~~/services/database/config/types";
@@ -66,10 +67,7 @@ export function GroupedChallenges({
       <div className="collapse collapse-arrow bg-base-300 rounded-lg">
         <input type="checkbox" defaultChecked />
         <div className="collapse-title text-base font-medium">
-          <div className="flex items-center gap-2">
-            <ChallengeIconComputer />
-            Ethereum 101
-          </div>
+          <GroupedChallengeTitle title="Ethereum 101" icon={<ChallengeIconComputer />} challenges={basicChallenges} />
         </div>
         <div className="collapse-content px-3 bg-base-100">
           <div className="mt-3 space-y-4 divide-y">
@@ -93,10 +91,11 @@ export function GroupedChallenges({
       <div className="mt-4 collapse collapse-arrow bg-base-300 rounded-lg">
         <input type="checkbox" />
         <div className="collapse-title text-base font-medium">
-          <div className="flex items-center gap-2">
-            <ChallengeIconRocket />
-            Advanced Concepts
-          </div>
+          <GroupedChallengeTitle
+            title="Advanced Concepts"
+            icon={<ChallengeIconRocket />}
+            challenges={advancedChallenges}
+          />
         </div>
         <div className="collapse-content px-3 bg-base-100">
           <div className="mt-3 space-y-4 divide-y">


### PR DESCRIPTION
Adds a new component `GroupedChallengeTitle` which calculates the completed challenges for the group and adds a progress bar:

<img width="1919" height="960" alt="Screenshot 2025-07-15 at 10 49 21 AM" src="https://github.com/user-attachments/assets/0ce39aa8-0200-47d2-acf6-ff97e5009f65" />
