### PR TITLE
Payload for new autograder

### DIFF
--- a/packages/nextjs/app/api/challenges/[challengeId]/submit/route.ts
+++ b/packages/nextjs/app/api/challenges/[challengeId]/submit/route.ts
@@ -75,7 +75,9 @@ export async function POST(req: NextRequest, { params }: { params: { challengeId
             { challengeId, originalReferrer: referrer },
             req,
           );
-          const autoGraderChallengeId = challenge.sortOrder;
+
+          // TODO: Won't work for simple-nft-example (update se-2-challenges branch OR update database (all relations!))
+          const autoGraderChallengeId = `challenge-${challenge.id}`;
 
           const gradingResult = await submitToAutograder({
             challengeId: autoGraderChallengeId,

--- a/packages/nextjs/services/autograder.ts
+++ b/packages/nextjs/services/autograder.ts
@@ -7,7 +7,7 @@ export async function submitToAutograder({
   challengeId,
   contractUrl,
 }: {
-  challengeId: number;
+  challengeId: string;
   contractUrl: string;
 }): Promise<AutogradingResult> {
   const contractUrlObject = new URL(contractUrl);


### PR DESCRIPTION
Because of https://github.com/austintgriffith/speedrun-grader/pull/24 and https://github.com/BuidlGuidl/SpeedRunEthereum-v2/issues/229

There is one issue with the IDs. Ideally, we'd want to use the `challenge.id` (pk from the `challenges` table) as the source of truth for everything

We have this enum in `database/config/types.ts`

```ts
export enum ChallengeId {
  SIMPLE_NFT_EXAMPLE = "simple-nft-example",
  DECENTRALIZED_STAKING = "decentralized-staking",
  TOKEN_VENDOR = "token-vendor",
  DICE_GAME = "dice-game",
  MINIMUM_VIABLE_EXCHANGE = "minimum-viable-exchange",
  OVER_COLLATERALIZED_LENDING = "over-collateralized-lending",
  STABLECOINS = "stablecoins",
  PREDICTION_MARKETS = "prediction-markets",
  DEPLOY_TO_L2 = "deploy-to-l2",
  MULTISIG = "multisig",
  SVG_NFT = "svg-nft",
  STATE_CHANNELS = "state-channels",
}
```

If we do `challenge-${challenge.id}`, I think all of them would work except the `challenge-simple-nft-example ` (since branch is `challenge-simple-nft`. We have a few options, from easier to hard:

1. Just use `challenge-simple-nft-example` as branch name in https://github.com/scaffold-eth/se-2-challenges
2. Get the right name from the github field from the database (`scaffold-eth/se-2-challenges:challenge-0-simple-nft`. We'd remove the 0 after merging this)
3. Update the database enum + update the database: challenges table + all the user submissions.

I'd probably go with 1 for now :D

### ToDo when merging
- [ ] Update Github field on each challenge (e.g. `scaffold-eth/se-2-challenges:challenge-1-decentralized-staking` to `scaffold-eth/se-2-challenges:challenge-decentralized-staking`. 


fixes #250 