### PR TITLE
Update build ideas repos to new ones

### DIFF
--- a/packages/nextjs/app/builders/[address]/_components/builds/BuildIdeas.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/builds/BuildIdeas.tsx
@@ -6,13 +6,13 @@ const BUILD_IDEAS = [
     name: "Multisig Wallet",
     description: "Secure assets by requiring multiple accounts to 'vote' on transactions.",
     imageUrl: "/assets/challenges/multiSig.svg",
-    url: "https://github.com/scaffold-eth/se-2-challenges/tree/challenge-6-multisig",
+    url: "https://github.com/scaffold-eth/se-2-challenges/tree/challenge-multisig",
   },
   {
     name: "SVG NFT",
     description: "Tinker around with cutting edge smart contracts that render SVGs in Solidity.",
     imageUrl: "/assets/challenges/dynamicSvgNFT.svg",
-    url: "https://github.com/scaffold-eth/se-2-challenges/tree/challenge-7-svg-nft",
+    url: "https://github.com/scaffold-eth/se-2-challenges/tree/challenge-svg-nft",
   },
 ];
 


### PR DESCRIPTION
Updated the "View build idea" links from numbered repos to the new ones without numbers. 

To verify need to login with a user with no builds:

<img width="1144" height="521" alt="image" src="https://github.com/user-attachments/assets/168f287e-582a-45cb-bc89-24ad9183ea3d" />