### PR TITLE
Remove Challenge Numbers from the Builder Profile Accordions

### DIFF
--- a/packages/nextjs/app/builders/[address]/_components/ChallengeDetails.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/ChallengeDetails.tsx
@@ -24,9 +24,6 @@ export function ChallengeDetails({
       <div className="mt-3 flex items-center justify-between gap-4">
         <div>
           <div className="flex items-center gap-2">
-            <div className="flex items-center justify-center w-6 h-6 bg-base-300 rounded-full font-semibold text-sm dark:bg-base-200">
-              {challenge.sortOrder}
-            </div>
             <h2 className="m-0 font-medium">
               <Link href={`/challenge/${challenge.id}`} className="hover:underline">
                 {challenge.challengeName}
@@ -34,7 +31,7 @@ export function ChallengeDetails({
               {comingSoon && ` - Coming Soon`}
             </h2>
           </div>
-          <div className="pl-8">
+          <div>
             <p className="mt-2 mb-0 text-sm">{shortedDescription}.</p>
           </div>
         </div>

--- a/packages/nextjs/app/builders/[address]/_components/ChallengeDetailsStatus.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/ChallengeDetailsStatus.tsx
@@ -23,9 +23,6 @@ export function ChallengeDetailsStatus({ challenge }: { challenge: MappedChallen
     <div>
       <div className="mt-3 flex flex-wrap items-center justify-between">
         <div className="flex items-center gap-2">
-          <div className="flex items-center justify-center w-6 h-6 bg-base-300 rounded-full font-semibold text-sm dark:bg-base-200">
-            {challenge.sortOrder}
-          </div>
           <h2 className="m-0 font-medium">
             <Link href={`/challenge/${challenge.id}`} className="hover:underline">
               {challenge.challengeName}
@@ -34,7 +31,7 @@ export function ChallengeDetailsStatus({ challenge }: { challenge: MappedChallen
         </div>
         <div className={`badge badge-sm py-3 px-3 ${badgeClass}`}>{challenge.reviewAction}</div>
       </div>
-      <div className="pl-8">
+      <div>
         <p className="mt-2 mb-0 text-sm">{shortedDescription}.</p>
         <div className={`mt-3 flex items-center gap-2 px-2 py-1 rounded-md ${statusAlertClass}`}>
           <div>

--- a/packages/nextjs/app/builders/[address]/_components/GroupedChallenges.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/GroupedChallenges.tsx
@@ -73,7 +73,7 @@ export function GroupedChallenges({
         <div className="collapse-title text-base font-medium">
           <GroupedChallengeTitle title="Ethereum 101" icon={<ChallengeIconComputer />} challenges={basicChallenges} />
         </div>
-        <div className="collapse-content px-3 bg-base-100">
+        <div className="collapse-content px-4 bg-base-100">
           <div className="mt-3 space-y-4 divide-y">
             {basicChallenges.map(challenge => {
               if (challenge.reviewAction) {
@@ -94,7 +94,7 @@ export function GroupedChallenges({
             challenges={advancedChallenges}
           />
         </div>
-        <div className="collapse-content px-3 bg-base-100">
+        <div className="collapse-content px-4 bg-base-100">
           <div className="mt-3 space-y-4 divide-y">
             {advancedChallenges.map(challenge => {
               if (challenge.reviewAction) {


### PR DESCRIPTION
Remove the challenge numbers `challenge.sortOrder` from the Builder Profile page.

<img width="1708" height="945" alt="Screenshot 2025-07-30 at 7 09 10 PM" src="https://github.com/user-attachments/assets/9ec1b2b4-2bdc-4a29-a5f0-d8ab1dba37ff" />
