### PR TITLE
Tweak Start button on homepage

### DIFF
--- a/packages/nextjs/app/_components/StartBuildingButton.tsx
+++ b/packages/nextjs/app/_components/StartBuildingButton.tsx
@@ -15,7 +15,8 @@ export const StartBuildingButton = () => {
     <Link
       href="/start"
       onClick={handleCtaClick}
-      className="mt-4 px-6 py-3 text-lg font-medium text-white bg-primary rounded-full hover:bg-secondary-content dark:text-gray-800 transition-colors"
+      className="mt-4 px-6 py-3 text-lg font-medium text-content bg-accent border-[3px] border-primary rounded-full hover:bg-accent-content 
+      hover:border-base-300 hover:text-base-300 dark:bg-base-200 transition-colors"
     >
       Start Building on Ethereum
     </Link>


### PR DESCRIPTION
Tweaked this button so it looks more like a button and not as much as part of the hero titles, as @phipsae  suggested.

<img width="1104" height="575" alt="Captura de pantalla 2025-07-30 a las 13 14 44" src="https://github.com/user-attachments/assets/8d2758df-a55f-42d6-b497-a8aa0df9abd5" />

This is how it looked:
<img width="1116" height="636" alt="Captura de pantalla 2025-07-30 a las 13 25 23" src="https://github.com/user-attachments/assets/0721cf09-85dd-4f9d-bdf2-e3c6187521da" />

I can also make it more obvious with square-rounded corners if you think it's still not there. What do you think?