### PR TITLE
Global error page

### DIFF
--- a/packages/nextjs/app/error.tsx
+++ b/packages/nextjs/app/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="relative bg-base-300">
+      <div className="absolute inset-0 bg-[url('/assets/home_header_clouds.svg')] bg-top bg-repeat-x bg-[length:auto_200px] sm:bg-[length:auto_300px]" />
+      <div className="relative container mx-auto px-5 mb-11 flex flex-col items-center">
+        <h1 className="mt-16 text-2xl font-semibold md:mt-32 md:text-5xl">Something went wrong!</h1>
+        <button className="btn btn-primary btn-lg md:mt-8" onClick={() => reset()}>
+          Try again
+        </button>
+      </div>
+      <div className="relative h-[130px]">
+        <div className="absolute inset-0 bg-[url('/assets/header_platform.svg')] bg-repeat-x bg-[length:auto_130px] z-10" />
+        <div className="bg-base-200 absolute inset-0 top-auto w-full h-5" />
+      </div>
+    </div>
+  );
+}

--- a/packages/nextjs/app/error.tsx
+++ b/packages/nextjs/app/error.tsx
@@ -1,12 +1,30 @@
 "use client";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  const isServerError = Boolean(error.digest);
+
   return (
     <div className="relative bg-base-300">
       <div className="absolute inset-0 bg-[url('/assets/home_header_clouds.svg')] bg-top bg-repeat-x bg-[length:auto_200px] sm:bg-[length:auto_300px]" />
       <div className="relative container mx-auto px-5 mb-11 flex flex-col items-center">
         <h1 className="mt-16 text-2xl font-semibold md:mt-32 md:text-5xl">Something went wrong!</h1>
+        <div className="mt-6 text-center font-bold">
+          {isServerError ? (
+            <>
+              Server-side error
+              <br />
+              Error digest: {error.digest}
+            </>
+          ) : (
+            <>
+              Client-side error
+              <br />
+              Error message: {error.message}
+              <br />
+              See the browser console for more information
+            </>
+          )}
+        </div>
         <button className="btn btn-primary btn-lg md:mt-8" onClick={() => reset()}>
           Try again
         </button>

--- a/packages/nextjs/app/global-error.tsx
+++ b/packages/nextjs/app/global-error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="relative bg-base-300">
+      <div className="absolute inset-0 bg-[url('/assets/home_header_clouds.svg')] bg-top bg-repeat-x bg-[length:auto_200px] sm:bg-[length:auto_300px]" />
+      <div className="relative container mx-auto px-5 mb-11 flex flex-col items-center">
+        <h1 className="mt-16 text-2xl font-semibold md:mt-32 md:text-5xl">Something went wrong!</h1>
+        <button className="btn btn-primary btn-lg md:mt-8" onClick={() => reset()}>
+          Try again
+        </button>
+      </div>
+      <div className="relative h-[130px]">
+        <div className="absolute inset-0 bg-[url('/assets/header_platform.svg')] bg-repeat-x bg-[length:auto_130px] z-10" />
+        <div className="bg-base-200 absolute inset-0 top-auto w-full h-5" />
+      </div>
+    </div>
+  );
+}

--- a/packages/nextjs/app/global-error.tsx
+++ b/packages/nextjs/app/global-error.tsx
@@ -1,12 +1,30 @@
 "use client";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  const isServerError = Boolean(error.digest);
+
   return (
     <div className="relative bg-base-300">
       <div className="absolute inset-0 bg-[url('/assets/home_header_clouds.svg')] bg-top bg-repeat-x bg-[length:auto_200px] sm:bg-[length:auto_300px]" />
       <div className="relative container mx-auto px-5 mb-11 flex flex-col items-center">
         <h1 className="mt-16 text-2xl font-semibold md:mt-32 md:text-5xl">Something went wrong!</h1>
+        <div className="mt-6 text-center font-bold">
+          {isServerError ? (
+            <>
+              Server-side error
+              <br />
+              Error digest: {error.digest}
+            </>
+          ) : (
+            <>
+              Client-side error
+              <br />
+              Error message: {error.message}
+              <br />
+              See the browser console for more information
+            </>
+          )}
+        </div>
         <button className="btn btn-primary btn-lg md:mt-8" onClick={() => reset()}>
           Try again
         </button>


### PR DESCRIPTION
If we have unhandled error on server or client, we have unhandled error page. Something like this:
<img width="1085" height="564" alt="image" src="https://github.com/user-attachments/assets/7581c60a-37d9-4f28-8610-5c7fafa08ae3" />

So if you try to add `throw new Error("test");` to any of these places:
- `getAllChallenges()` function
- `page.tsx` - `Home` component
- `HomepageClient.tsx`
and try to load main page, you'll get error page.

`global-error.tsx` fixes it, so when getting error we'll have an our custom error page 
<img width="1255" height="627" alt="image" src="https://github.com/user-attachments/assets/92114376-f76c-4add-a4f1-6117de917c95" />

Docs: 
https://nextjs.org/docs/14/app/building-your-application/routing/error-handling#handling-errors-in-root-layouts

Also added `error.tsx` since it's recommended
<img width="832" height="126" alt="image" src="https://github.com/user-attachments/assets/23ede19e-2cc6-41de-9b2f-188e667c00c5" />

and see also
<img width="826" height="144" alt="image" src="https://github.com/user-attachments/assets/e45e74c9-cd9d-45bc-b8e5-983d01c3bbed" />

Fixes #99 