### PR TITLE
hotfix: challenge readme github resolution

### DIFF
--- a/packages/nextjs/services/github.ts
+++ b/packages/nextjs/services/github.ts
@@ -19,7 +19,13 @@ export function parseGithubUrl(githubString: string): GithubRepoInfo {
 
 export async function fetchGithubChallengeReadme(githubString: string): Promise<string> {
   const { owner, repo, branch } = parseGithubUrl(githubString);
-  const readmeUrl = `${GITHUB_RAW_BASE_URL}/${owner}/${repo}/${branch}/README.md`;
+
+  // TODO: Remove this hotfix after github url scaffold-eth/se-2-challenges  works correctly
+  let correctOwner = owner;
+  if (owner === "scaffold-eth" && repo === "se-2-challenges") {
+    correctOwner = "BuidlGuidl";
+  }
+  const readmeUrl = `${GITHUB_RAW_BASE_URL}/${correctOwner}/${repo}/${branch}/README.md`;
 
   const response = await fetch(readmeUrl);
   if (!response.ok) {


### PR DESCRIPTION
### Description: 

There seems some problem with SE-2 challenge repo under scaffold-eth org. For now just forked that repo under Buidlguidl and seems to work 