### PR TITLE
Block new readme folder in robots and add redirect from broken external links

### DIFF
--- a/packages/nextjs/next.config.ts
+++ b/packages/nextjs/next.config.ts
@@ -33,6 +33,11 @@ const nextConfig: NextConfig = {
         destination: "/challenge/dex",
         permanent: true,
       },
+      {
+        source: "/challenge/state-channels",
+        destination: "/",
+        permanent: true,
+      },
     ];
   },
 };

--- a/packages/nextjs/public/robots.txt
+++ b/packages/nextjs/public/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Disallow: /builders/
 Disallow: /builds/
+Disallow: /readme/
 Allow: /
 Sitemap: https://speedrunethereum.com/sitemap.xml


### PR DESCRIPTION
This is a small PR to:

- Block (just in case) the new readme folder in robots to prevent duplicated content. Added in #279 
- Add a redirect from a broken link (we have some websites linking to state-channels challenge), to prevent a 404.