### PR TITLE
Loading signature text + Be consistent with loading states

### DIFF
--- a/packages/nextjs/app/_components/JoinBatchButton.tsx
+++ b/packages/nextjs/app/_components/JoinBatchButton.tsx
@@ -72,7 +72,7 @@ const JoinBatchButton = ({ userChallenges = [], latestOpenBatch, isLoadingLatest
         <button
           disabled
           className={`flex justify-center text-violet bg-violet-light items-center text-sm sm:text-lg px-4 py-1 border-2 border-violet rounded-full hover:bg-opacity-80 disabled:opacity-70 disabled:hover:bg-opacity-100 ${lockReason ? "cursor-not-allowed hover:bg-violet-light" : ""}`}
-          onClick={handleJoinBatch}
+          onClick={() => handleJoinBatch()}
         >
           <PadLockIcon className="w-4 h-4 sm:w-6 sm:h-6 mr-2" fill="#606CCF" />
           <span className="uppercase">Locked</span>
@@ -113,11 +113,10 @@ const JoinBatchButton = ({ userChallenges = [], latestOpenBatch, isLoadingLatest
   return (
     <button
       className={`flex justify-center text-black bg-violet-light items-center text-sm sm:text-lg px-4 py-1 border-2 border-violet rounded-full hover:bg-opacity-80 disabled:opacity-70 disabled:hover:bg-opacity-100 disabled:cursor-not-allowed`}
-      onClick={handleJoinBatch}
+      onClick={() => handleJoinBatch()}
       disabled={isJoiningBatch}
     >
-      {!isJoiningBatch && <span>Get Telegram Access</span>}
-      {isJoiningBatch && <span className="mr-2">Getting Telegram Access...</span>}
+      {isJoiningBatch ? <span className="loading loading-spinner loading-sm"></span> : <span>Get Telegram Access</span>}
     </button>
   );
 };

--- a/packages/nextjs/app/_components/RegisterUser.tsx
+++ b/packages/nextjs/app/_components/RegisterUser.tsx
@@ -55,7 +55,7 @@ export const RegisterUser = () => {
           )}
           <button
             className="flex items-center justify-center py-1.5 lg:py-2 px-3 lg:px-4 border-2 border-primary rounded-full bg-base-300 hover:bg-base-200 transition-colors cursor-pointer mt-4 text-sm w-full"
-            onClick={() => handleRegister(storedReferrer, parsedUtmParams)}
+            onClick={() => handleRegister({ referrer: storedReferrer, originalUtmParams: parsedUtmParams })}
             disabled={isRegistering}
           >
             {isRegistering ? (

--- a/packages/nextjs/app/_components/UpdateUserModal.tsx
+++ b/packages/nextjs/app/_components/UpdateUserModal.tsx
@@ -131,7 +131,7 @@ export const UpdateUserModal = ({ user, onSuccess }: UpdateUserModalProps) => {
 
             <div className="mt-6 flex justify-end">
               <button className="btn btn-primary" disabled={isPending} onClick={handleUpdate}>
-                {isPending ? "Updating..." : "Update"}
+                {isPending ? <span className="loading loading-spinner loading-sm"></span> : "Update"}
               </button>
             </div>
           </div>

--- a/packages/nextjs/app/admin/batches/_components/BatchModalContent.tsx
+++ b/packages/nextjs/app/admin/batches/_components/BatchModalContent.tsx
@@ -74,8 +74,7 @@ export const BatchModalContent = forwardRef<HTMLInputElement, BatchModalContentP
     const title = batchOperation === "add" ? "Add New Batch" : "Edit Batch";
 
     const buttonDefaultText = batchOperation === "add" ? "Add Batch" : "Update Batch";
-    const buttonLoadingText = batchOperation === "add" ? "Adding..." : "Updating...";
-    const buttonText = isPending ? buttonLoadingText : buttonDefaultText;
+    const buttonText = isPending ? <span className="loading loading-spinner loading-sm"></span> : buttonDefaultText;
 
     const handleUpdateBatch = () => {
       if (!name || !startDate || !telegramLink) {

--- a/packages/nextjs/app/builders/[address]/_components/UpdateLocationModal.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/UpdateLocationModal.tsx
@@ -74,7 +74,7 @@ export const UpdateLocationModal = forwardRef<HTMLDivElement, UpdateLocationModa
                 onClick={() => updateLocation(selectedCountry)}
                 disabled={isPending || selectedCountry === (existingLocation ?? "")}
               >
-                Update Location
+                {isPending ? <span className="loading loading-spinner loading-sm"></span> : "Update Location"}
               </button>
             </div>
           </div>

--- a/packages/nextjs/app/builders/[address]/_components/builds/BuildFormModal.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/builds/BuildFormModal.tsx
@@ -346,7 +346,6 @@ export const BuildFormModal = forwardRef<HTMLDialogElement, BuildFormModalProps>
                 {isPending ? (
                   <>
                     <span className="loading loading-spinner loading-sm"></span>
-                    {buttonText}
                   </>
                 ) : (
                   buttonText

--- a/packages/nextjs/app/builders/[address]/_components/builds/DeleteBuildButton.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/builds/DeleteBuildButton.tsx
@@ -21,7 +21,7 @@ export const DeleteBuildButton = ({ buildId, ownerAddress }: { buildId: string; 
       aria-label="Delete"
       disabled={isPending}
     >
-      <TrashIcon className="h-5 w-5" />
+      {isPending ? <span className="loading loading-spinner loading-sm"></span> : <TrashIcon className="h-5 w-5" />}
     </button>
   );
 };

--- a/packages/nextjs/app/builders/[address]/_components/builds/LikeBuildButton.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/builds/LikeBuildButton.tsx
@@ -29,7 +29,9 @@ export const LikeBuildButton = ({ buildId, likes, onSuccess }: LikeBuildBtnProps
       onClick={() => likeBuildMutation({ buildId, action: isLiked ? "unlike" : "like" })}
       disabled={isPending}
     >
-      {isLiked ? (
+      {isPending ? (
+        <span className="loading loading-spinner loading-sm"></span>
+      ) : isLiked ? (
         <HeartIconSolid className="h-5 w-5 text-red-500 transition-transform duration-150 group-hover:scale-110" />
       ) : (
         <HeartIconOutline className="h-5 w-5 transition-transform duration-150 group-hover:scale-110 group-hover:text-red-500" />

--- a/packages/nextjs/app/challenge/[challengeId]/_components/SubmitChallengeModal.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/SubmitChallengeModal.tsx
@@ -67,14 +67,7 @@ export const SubmitChallengeModal = forwardRef<HTMLDialogElement, SubmitChalleng
                 disabled={!Boolean(frontendUrl && contractUrl) || isPending}
                 onClick={() => submitChallenge({ challengeId, frontendUrl, contractUrl })}
               >
-                {isPending ? (
-                  <>
-                    <span className="loading loading-spinner loading-xs"></span>
-                    Submitting...
-                  </>
-                ) : (
-                  "Submit Challenge"
-                )}
+                {isPending ? <span className="loading loading-spinner loading-xs"></span> : "Submit Challenge"}
               </button>
             </div>
           </div>

--- a/packages/nextjs/app/challenge/[challengeId]/_components/WelcomeBanner.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/WelcomeBanner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLocalStorage } from "usehooks-ts";
 import { useAccount } from "wagmi";
 import { RainbowKitCustomConnectButton } from "~~/components/scaffold-eth/RainbowKitCustomConnectButton";
 import { useUser } from "~~/hooks/useUser";
@@ -9,6 +10,9 @@ export const WelcomeBanner = () => {
   const { address: connectedAddress } = useAccount();
   const { data: user, isLoading: isLoadingUser } = useUser(connectedAddress);
   const { handleRegister, isRegistering } = useUserRegister();
+  const [storedReferrer] = useLocalStorage<string | null>("originalReferrer", null);
+  const [storedUtmParams] = useLocalStorage<string | null>("originalUtmParams", null);
+  const parsedUtmParams = storedUtmParams ? JSON.parse(storedUtmParams) : undefined;
 
   if (user || isLoadingUser) {
     return null;
@@ -41,7 +45,16 @@ export const WelcomeBanner = () => {
           {!isWalletConnected ? (
             <RainbowKitCustomConnectButton />
           ) : (
-            <button className="btn btn-primary" onClick={() => handleRegister(null)} disabled={isRegistering}>
+            <button
+              className="btn btn-primary"
+              onClick={() =>
+                handleRegister({
+                  referrer: storedReferrer,
+                  originalUtmParams: parsedUtmParams,
+                })
+              }
+              disabled={isRegistering}
+            >
               {isRegistering ? (
                 <span className="loading loading-spinner loading-sm"></span>
               ) : (

--- a/packages/nextjs/app/start/_components/ConnectAndRegisterSection.tsx
+++ b/packages/nextjs/app/start/_components/ConnectAndRegisterSection.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { useLocalStorage } from "usehooks-ts";
 import { useAccount } from "wagmi";
 import { useUser } from "~~/hooks/useUser";
 import { useUserRegister } from "~~/hooks/useUserRegister";
@@ -13,6 +14,9 @@ export const ConnectAndRegisterSection = () => {
   const { data: user, isLoading: isLoadingUser } = useUser(connectedAddress);
   const { handleRegister, isRegistering } = useUserRegister();
   const [isLocalLoading, setIsLocalLoading] = useState(false);
+  const [storedReferrer] = useLocalStorage<string | null>("originalReferrer", null);
+  const [storedUtmParams] = useLocalStorage<string | null>("originalUtmParams", null);
+  const parsedUtmParams = storedUtmParams ? JSON.parse(storedUtmParams) : undefined;
   const router = useRouter();
 
   const isWalletConnected = !!connectedAddress;
@@ -21,7 +25,7 @@ export const ConnectAndRegisterSection = () => {
   const handleRegisterClick = async () => {
     setIsLocalLoading(true);
     try {
-      await handleRegister(null);
+      await handleRegister({ referrer: storedReferrer, originalUtmParams: parsedUtmParams });
     } catch (error) {
       console.error("Registration failed:", error);
     } finally {

--- a/packages/nextjs/hooks/useBuildLike.tsx
+++ b/packages/nextjs/hooks/useBuildLike.tsx
@@ -1,14 +1,14 @@
 import { useRouter } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
 import { useAccount } from "wagmi";
-import { useSignTypedData } from "wagmi";
+import { useSignatureWithNotification } from "~~/hooks/useSignatureWithNotification";
 import { likeBuild } from "~~/services/api/users/builds";
 import { EIP_712_TYPED_DATA__LIKE_BUILD } from "~~/services/eip712/builds";
 import { notification } from "~~/utils/scaffold-eth";
 
 export function useBuildLike({ onSuccess }: { onSuccess?: () => void }) {
   const { address } = useAccount();
-  const { signTypedDataAsync } = useSignTypedData();
+  const { signWithNotification } = useSignatureWithNotification();
   const router = useRouter();
 
   const { mutate: likeBuildMutation, isPending } = useMutation({
@@ -20,16 +20,10 @@ export function useBuildLike({ onSuccess }: { onSuccess?: () => void }) {
         action,
       };
 
-      let signature: `0x${string}` | undefined;
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      try {
-        signature = await signTypedDataAsync({
-          ...EIP_712_TYPED_DATA__LIKE_BUILD,
-          message,
-        });
-      } finally {
-        notification.remove(loadingNotificationId);
-      }
+      const signature = await signWithNotification({
+        ...EIP_712_TYPED_DATA__LIKE_BUILD,
+        message,
+      });
 
       return likeBuild({ address, signature, buildId });
     },

--- a/packages/nextjs/hooks/useBuildLike.tsx
+++ b/packages/nextjs/hooks/useBuildLike.tsx
@@ -15,17 +15,21 @@ export function useBuildLike({ onSuccess }: { onSuccess?: () => void }) {
     mutationFn: async ({ buildId, action }: { buildId: string; action: "like" | "unlike" }) => {
       if (!address) throw new Error("Wallet not connected");
 
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         buildId,
         action,
       };
 
-      const signature = await signTypedDataAsync({
-        ...EIP_712_TYPED_DATA__LIKE_BUILD,
-        message,
-      });
-      notification.remove(loadingNotificationId);
+      let signature: `0x${string}` | undefined;
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
+      try {
+        signature = await signTypedDataAsync({
+          ...EIP_712_TYPED_DATA__LIKE_BUILD,
+          message,
+        });
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       return likeBuild({ address, signature, buildId });
     },

--- a/packages/nextjs/hooks/useBuildLike.tsx
+++ b/packages/nextjs/hooks/useBuildLike.tsx
@@ -15,6 +15,7 @@ export function useBuildLike({ onSuccess }: { onSuccess?: () => void }) {
     mutationFn: async ({ buildId, action }: { buildId: string; action: "like" | "unlike" }) => {
       if (!address) throw new Error("Wallet not connected");
 
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         buildId,
         action,
@@ -24,6 +25,7 @@ export function useBuildLike({ onSuccess }: { onSuccess?: () => void }) {
         ...EIP_712_TYPED_DATA__LIKE_BUILD,
         message,
       });
+      notification.remove(loadingNotificationId);
 
       return likeBuild({ address, signature, buildId });
     },

--- a/packages/nextjs/hooks/useCreateBatch.ts
+++ b/packages/nextjs/hooks/useCreateBatch.ts
@@ -21,17 +21,21 @@ export const useCreateBatch = ({ onSuccess }: { onSuccess?: () => void }) => {
         network: batch.network,
       };
 
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__CREATE_BATCH.message,
         ...updatedBatch,
       };
 
-      const signature = await signTypedDataAsync({
-        ...EIP_712_TYPED_DATA__CREATE_BATCH,
-        message,
-      });
-      notification.remove(loadingNotificationId);
+      let signature: `0x${string}` | undefined;
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
+      try {
+        signature = await signTypedDataAsync({
+          ...EIP_712_TYPED_DATA__CREATE_BATCH,
+          message,
+        });
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       return fetchCreateBatch({ ...updatedBatch, address, signature });
     },

--- a/packages/nextjs/hooks/useCreateBatch.ts
+++ b/packages/nextjs/hooks/useCreateBatch.ts
@@ -21,6 +21,7 @@ export const useCreateBatch = ({ onSuccess }: { onSuccess?: () => void }) => {
         network: batch.network,
       };
 
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__CREATE_BATCH.message,
         ...updatedBatch,
@@ -30,6 +31,7 @@ export const useCreateBatch = ({ onSuccess }: { onSuccess?: () => void }) => {
         ...EIP_712_TYPED_DATA__CREATE_BATCH,
         message,
       });
+      notification.remove(loadingNotificationId);
 
       return fetchCreateBatch({ ...updatedBatch, address, signature });
     },

--- a/packages/nextjs/hooks/useDeleteBuild.ts
+++ b/packages/nextjs/hooks/useDeleteBuild.ts
@@ -1,7 +1,7 @@
 import { useRouter } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
-import { useSignTypedData } from "wagmi";
 import { useAccount } from "wagmi";
+import { useSignatureWithNotification } from "~~/hooks/useSignatureWithNotification";
 import { deleteBuild as deleteBuildApi } from "~~/services/api/users/builds";
 import { EIP_712_TYPED_DATA__DELETE_BUILD } from "~~/services/eip712/builds";
 import { notification } from "~~/utils/scaffold-eth";
@@ -9,7 +9,7 @@ import { notification } from "~~/utils/scaffold-eth";
 export function useDeleteBuild() {
   const router = useRouter();
   const { address: connectedAddress } = useAccount();
-  const { signTypedDataAsync } = useSignTypedData();
+  const { signWithNotification } = useSignatureWithNotification();
 
   const { mutate: deleteBuild, isPending } = useMutation({
     mutationFn: async ({ buildId, ownerAddress }: { buildId: string; ownerAddress: string }) => {
@@ -20,16 +20,10 @@ export function useDeleteBuild() {
         id: buildId,
       };
 
-      let signature: `0x${string}` | undefined;
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      try {
-        signature = await signTypedDataAsync({
-          ...EIP_712_TYPED_DATA__DELETE_BUILD,
-          message,
-        });
-      } finally {
-        notification.remove(loadingNotificationId);
-      }
+      const signature = await signWithNotification({
+        ...EIP_712_TYPED_DATA__DELETE_BUILD,
+        message,
+      });
 
       return deleteBuildApi({ signatureAddress: connectedAddress, signature, buildId, userAddress: ownerAddress });
     },

--- a/packages/nextjs/hooks/useDeleteBuild.ts
+++ b/packages/nextjs/hooks/useDeleteBuild.ts
@@ -15,17 +15,21 @@ export function useDeleteBuild() {
     mutationFn: async ({ buildId, ownerAddress }: { buildId: string; ownerAddress: string }) => {
       if (!connectedAddress) throw new Error("Wallet not connected");
 
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__DELETE_BUILD.message,
         id: buildId,
       };
 
-      const signature = await signTypedDataAsync({
-        ...EIP_712_TYPED_DATA__DELETE_BUILD,
-        message,
-      });
-      notification.remove(loadingNotificationId);
+      let signature: `0x${string}` | undefined;
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
+      try {
+        signature = await signTypedDataAsync({
+          ...EIP_712_TYPED_DATA__DELETE_BUILD,
+          message,
+        });
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       return deleteBuildApi({ signatureAddress: connectedAddress, signature, buildId, userAddress: ownerAddress });
     },

--- a/packages/nextjs/hooks/useDeleteBuild.ts
+++ b/packages/nextjs/hooks/useDeleteBuild.ts
@@ -15,6 +15,7 @@ export function useDeleteBuild() {
     mutationFn: async ({ buildId, ownerAddress }: { buildId: string; ownerAddress: string }) => {
       if (!connectedAddress) throw new Error("Wallet not connected");
 
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__DELETE_BUILD.message,
         id: buildId,
@@ -24,6 +25,7 @@ export function useDeleteBuild() {
         ...EIP_712_TYPED_DATA__DELETE_BUILD,
         message,
       });
+      notification.remove(loadingNotificationId);
 
       return deleteBuildApi({ signatureAddress: connectedAddress, signature, buildId, userAddress: ownerAddress });
     },

--- a/packages/nextjs/hooks/useJoinBatch.tsx
+++ b/packages/nextjs/hooks/useJoinBatch.tsx
@@ -25,7 +25,9 @@ export function useJoinBatch({ user }: { user?: UserByAddress }) {
     if (!user) return;
 
     try {
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const signature = await signTypedDataAsync(EIP_712_TYPED_DATA__JOIN_BATCH);
+      notification.remove(loadingNotificationId);
       joinBatch({ address: user.userAddress, signature });
     } catch (error) {
       console.error("Error during signature:", error);

--- a/packages/nextjs/hooks/useJoinBatch.tsx
+++ b/packages/nextjs/hooks/useJoinBatch.tsx
@@ -25,9 +25,13 @@ export function useJoinBatch({ user }: { user?: UserByAddress }) {
     if (!user) return;
 
     try {
+      let signature: `0x${string}` | undefined;
       const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      const signature = await signTypedDataAsync(EIP_712_TYPED_DATA__JOIN_BATCH);
-      notification.remove(loadingNotificationId);
+      try {
+        signature = await signTypedDataAsync(EIP_712_TYPED_DATA__JOIN_BATCH);
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
       joinBatch({ address: user.userAddress, signature });
     } catch (error) {
       console.error("Error during signature:", error);

--- a/packages/nextjs/hooks/useJoinBatch.tsx
+++ b/packages/nextjs/hooks/useJoinBatch.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useSignTypedData } from "wagmi";
+import { useSignatureWithNotification } from "~~/hooks/useSignatureWithNotification";
 import { userJoinBatch } from "~~/services/api/users";
 import { UserByAddress } from "~~/services/database/repositories/users";
 import { EIP_712_TYPED_DATA__JOIN_BATCH } from "~~/services/eip712/join-batch";
@@ -7,19 +7,13 @@ import { notification } from "~~/utils/scaffold-eth";
 
 export function useJoinBatch({ user }: { user?: UserByAddress }) {
   const queryClient = useQueryClient();
-  const { signTypedDataAsync } = useSignTypedData();
+  const { signWithNotification } = useSignatureWithNotification();
 
   const { mutateAsync: joinBatchMutation, isPending: isJoiningBatch } = useMutation({
     mutationFn: async () => {
       if (!user) throw new Error("User not found");
 
-      let signature: `0x${string}` | undefined;
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      try {
-        signature = await signTypedDataAsync(EIP_712_TYPED_DATA__JOIN_BATCH);
-      } finally {
-        notification.remove(loadingNotificationId);
-      }
+      const signature = await signWithNotification(EIP_712_TYPED_DATA__JOIN_BATCH);
 
       return userJoinBatch({ address: user.userAddress, signature });
     },

--- a/packages/nextjs/hooks/useSignatureWithNotification.ts
+++ b/packages/nextjs/hooks/useSignatureWithNotification.ts
@@ -1,0 +1,26 @@
+import { useSignTypedData } from "wagmi";
+import { notification } from "~~/utils/scaffold-eth";
+
+/**
+ * Hook to handle signature with loading notification
+ * @returns signWithNotification function that takes typedData and optional loading message
+ */
+export function useSignatureWithNotification() {
+  const { signTypedDataAsync } = useSignTypedData();
+
+  const signWithNotification = async (
+    typedData: any,
+    loadingMessage = "Awaiting for Wallet signature...",
+  ): Promise<`0x${string}`> => {
+    const loadingNotificationId = notification.loading(loadingMessage);
+
+    try {
+      const signature = await signTypedDataAsync(typedData);
+      return signature;
+    } finally {
+      notification.remove(loadingNotificationId);
+    }
+  };
+
+  return { signWithNotification };
+}

--- a/packages/nextjs/hooks/useSubmitBuild.tsx
+++ b/packages/nextjs/hooks/useSubmitBuild.tsx
@@ -28,6 +28,7 @@ export function useSubmitBuild({ onSuccess }: { onSuccess?: () => void }) {
         coBuilders: build.coBuilders || [],
       };
 
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__SUBMIT_BUILD.message,
         ...buildWithDefaults,
@@ -37,6 +38,7 @@ export function useSubmitBuild({ onSuccess }: { onSuccess?: () => void }) {
         ...EIP_712_TYPED_DATA__SUBMIT_BUILD,
         message,
       });
+      notification.remove(loadingNotificationId);
 
       return submitBuild({ address, signature, ...build });
     },

--- a/packages/nextjs/hooks/useSubmitBuild.tsx
+++ b/packages/nextjs/hooks/useSubmitBuild.tsx
@@ -28,17 +28,21 @@ export function useSubmitBuild({ onSuccess }: { onSuccess?: () => void }) {
         coBuilders: build.coBuilders || [],
       };
 
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__SUBMIT_BUILD.message,
         ...buildWithDefaults,
       };
 
-      const signature = await signTypedDataAsync({
-        ...EIP_712_TYPED_DATA__SUBMIT_BUILD,
-        message,
-      });
-      notification.remove(loadingNotificationId);
+      let signature: `0x${string}` | undefined;
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
+      try {
+        signature = await signTypedDataAsync({
+          ...EIP_712_TYPED_DATA__SUBMIT_BUILD,
+          message,
+        });
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       return submitBuild({ address, signature, ...build });
     },

--- a/packages/nextjs/hooks/useSubmitChallenge.ts
+++ b/packages/nextjs/hooks/useSubmitChallenge.ts
@@ -54,6 +54,7 @@ export const useSubmitChallenge = ({ onSuccess }: { onSuccess?: () => void }) =>
 
       validateUrls(submitChallengeParams);
 
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__CHALLENGE_SUBMIT.message,
         ...submitChallengeParams,
@@ -63,6 +64,7 @@ export const useSubmitChallenge = ({ onSuccess }: { onSuccess?: () => void }) =>
         ...EIP_712_TYPED_DATA__CHALLENGE_SUBMIT,
         message,
       });
+      notification.remove(loadingNotificationId);
 
       return submitChallenge({
         userAddress: address,

--- a/packages/nextjs/hooks/useSubmitChallenge.ts
+++ b/packages/nextjs/hooks/useSubmitChallenge.ts
@@ -54,17 +54,21 @@ export const useSubmitChallenge = ({ onSuccess }: { onSuccess?: () => void }) =>
 
       validateUrls(submitChallengeParams);
 
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__CHALLENGE_SUBMIT.message,
         ...submitChallengeParams,
       };
 
-      const signature = await signTypedDataAsync({
-        ...EIP_712_TYPED_DATA__CHALLENGE_SUBMIT,
-        message,
-      });
-      notification.remove(loadingNotificationId);
+      let signature: `0x${string}` | undefined;
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
+      try {
+        signature = await signTypedDataAsync({
+          ...EIP_712_TYPED_DATA__CHALLENGE_SUBMIT,
+          message,
+        });
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       return submitChallenge({
         userAddress: address,

--- a/packages/nextjs/hooks/useUpdateBatch.ts
+++ b/packages/nextjs/hooks/useUpdateBatch.ts
@@ -18,7 +18,6 @@ export const useUpdateBatch = ({ onSuccess }: { onSuccess?: () => void }) => {
     }: { batchId: string } & Omit<BatchInsert, "startDate"> & { startDate: string }) => {
       if (!address) throw new Error("Wallet not connected");
 
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__UPDATE_BATCH.message,
         name: batch.name,
@@ -30,11 +29,16 @@ export const useUpdateBatch = ({ onSuccess }: { onSuccess?: () => void }) => {
         network: batch.network,
       };
 
-      const signature = await signTypedDataAsync({
-        ...EIP_712_TYPED_DATA__UPDATE_BATCH,
-        message,
-      });
-      notification.remove(loadingNotificationId);
+      let signature: `0x${string}` | undefined;
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
+      try {
+        signature = await signTypedDataAsync({
+          ...EIP_712_TYPED_DATA__UPDATE_BATCH,
+          message,
+        });
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       return fetchUpdateBatch(batchId, {
         address,

--- a/packages/nextjs/hooks/useUpdateBatch.ts
+++ b/packages/nextjs/hooks/useUpdateBatch.ts
@@ -1,6 +1,7 @@
 import { useRouter } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
-import { useAccount, useSignTypedData } from "wagmi";
+import { useAccount } from "wagmi";
+import { useSignatureWithNotification } from "~~/hooks/useSignatureWithNotification";
 import { fetchUpdateBatch } from "~~/services/api/batches";
 import { BatchInsert } from "~~/services/database/repositories/batches";
 import { EIP_712_TYPED_DATA__UPDATE_BATCH } from "~~/services/eip712/batches";
@@ -9,7 +10,7 @@ import { notification } from "~~/utils/scaffold-eth";
 export const useUpdateBatch = ({ onSuccess }: { onSuccess?: () => void }) => {
   const router = useRouter();
   const { address } = useAccount();
-  const { signTypedDataAsync } = useSignTypedData();
+  const { signWithNotification } = useSignatureWithNotification();
 
   const { mutate: updateBatchMutation, isPending } = useMutation({
     mutationFn: async ({
@@ -29,16 +30,10 @@ export const useUpdateBatch = ({ onSuccess }: { onSuccess?: () => void }) => {
         network: batch.network,
       };
 
-      let signature: `0x${string}` | undefined;
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      try {
-        signature = await signTypedDataAsync({
-          ...EIP_712_TYPED_DATA__UPDATE_BATCH,
-          message,
-        });
-      } finally {
-        notification.remove(loadingNotificationId);
-      }
+      const signature = await signWithNotification({
+        ...EIP_712_TYPED_DATA__UPDATE_BATCH,
+        message,
+      });
 
       return fetchUpdateBatch(batchId, {
         address,

--- a/packages/nextjs/hooks/useUpdateBatch.ts
+++ b/packages/nextjs/hooks/useUpdateBatch.ts
@@ -18,6 +18,7 @@ export const useUpdateBatch = ({ onSuccess }: { onSuccess?: () => void }) => {
     }: { batchId: string } & Omit<BatchInsert, "startDate"> & { startDate: string }) => {
       if (!address) throw new Error("Wallet not connected");
 
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__UPDATE_BATCH.message,
         name: batch.name,
@@ -33,6 +34,7 @@ export const useUpdateBatch = ({ onSuccess }: { onSuccess?: () => void }) => {
         ...EIP_712_TYPED_DATA__UPDATE_BATCH,
         message,
       });
+      notification.remove(loadingNotificationId);
 
       return fetchUpdateBatch(batchId, {
         address,

--- a/packages/nextjs/hooks/useUpdateBuild.ts
+++ b/packages/nextjs/hooks/useUpdateBuild.ts
@@ -36,18 +36,22 @@ export function useUpdateBuild({ onSuccess }: { onSuccess?: () => void }) {
         coBuilders: build.coBuilders || [],
       };
 
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         buildId,
         ...EIP_712_TYPED_DATA__UPDATE_BUILD.message,
         ...buildWithDefaults,
       };
 
-      const signature = await signTypedDataAsync({
-        ...EIP_712_TYPED_DATA__UPDATE_BUILD,
-        message,
-      });
-      notification.remove(loadingNotificationId);
+      let signature: `0x${string}` | undefined;
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
+      try {
+        signature = await signTypedDataAsync({
+          ...EIP_712_TYPED_DATA__UPDATE_BUILD,
+          message,
+        });
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       return updateBuild({ signatureAddress: connectedAddress, signature, build, userAddress: ownerAddress }, buildId);
     },

--- a/packages/nextjs/hooks/useUpdateBuild.ts
+++ b/packages/nextjs/hooks/useUpdateBuild.ts
@@ -1,8 +1,8 @@
 import { useRouter } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
-import { useSignTypedData } from "wagmi";
 import { useAccount } from "wagmi";
 import { BuildFormInputs } from "~~/app/builders/[address]/_components/builds/BuildFormModal";
+import { useSignatureWithNotification } from "~~/hooks/useSignatureWithNotification";
 import { updateBuild } from "~~/services/api/users/builds";
 import { EIP_712_TYPED_DATA__UPDATE_BUILD } from "~~/services/eip712/builds";
 import { notification } from "~~/utils/scaffold-eth";
@@ -10,7 +10,7 @@ import { notification } from "~~/utils/scaffold-eth";
 export function useUpdateBuild({ onSuccess }: { onSuccess?: () => void }) {
   const router = useRouter();
   const { address: connectedAddress } = useAccount();
-  const { signTypedDataAsync } = useSignTypedData();
+  const { signWithNotification } = useSignatureWithNotification();
 
   const { mutateAsync: updateBuildMutation, isPending } = useMutation({
     mutationFn: async ({
@@ -42,16 +42,10 @@ export function useUpdateBuild({ onSuccess }: { onSuccess?: () => void }) {
         ...buildWithDefaults,
       };
 
-      let signature: `0x${string}` | undefined;
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      try {
-        signature = await signTypedDataAsync({
-          ...EIP_712_TYPED_DATA__UPDATE_BUILD,
-          message,
-        });
-      } finally {
-        notification.remove(loadingNotificationId);
-      }
+      const signature = await signWithNotification({
+        ...EIP_712_TYPED_DATA__UPDATE_BUILD,
+        message,
+      });
 
       return updateBuild({ signatureAddress: connectedAddress, signature, build, userAddress: ownerAddress }, buildId);
     },

--- a/packages/nextjs/hooks/useUpdateBuild.ts
+++ b/packages/nextjs/hooks/useUpdateBuild.ts
@@ -36,6 +36,7 @@ export function useUpdateBuild({ onSuccess }: { onSuccess?: () => void }) {
         coBuilders: build.coBuilders || [],
       };
 
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         buildId,
         ...EIP_712_TYPED_DATA__UPDATE_BUILD.message,
@@ -46,6 +47,7 @@ export function useUpdateBuild({ onSuccess }: { onSuccess?: () => void }) {
         ...EIP_712_TYPED_DATA__UPDATE_BUILD,
         message,
       });
+      notification.remove(loadingNotificationId);
 
       return updateBuild({ signatureAddress: connectedAddress, signature, build, userAddress: ownerAddress }, buildId);
     },

--- a/packages/nextjs/hooks/useUpdateEns.ts
+++ b/packages/nextjs/hooks/useUpdateEns.ts
@@ -1,6 +1,7 @@
 import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAccount, useSignTypedData } from "wagmi";
+import { useAccount } from "wagmi";
+import { useSignatureWithNotification } from "~~/hooks/useSignatureWithNotification";
 import { EIP_712_TYPED_DATA__UPDATE_ENS } from "~~/services/eip712/ens";
 import { notification } from "~~/utils/scaffold-eth";
 
@@ -8,19 +9,13 @@ export function useUpdateEns() {
   const { address } = useAccount();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { signTypedDataAsync } = useSignTypedData();
+  const { signWithNotification } = useSignatureWithNotification();
 
   const { mutate: updateEns, isPending: isUpdatingEns } = useMutation({
     mutationFn: async () => {
       if (!address) throw new Error("Wallet not connected");
 
-      let signature: `0x${string}` | undefined;
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      try {
-        signature = await signTypedDataAsync(EIP_712_TYPED_DATA__UPDATE_ENS);
-      } finally {
-        notification.remove(loadingNotificationId);
-      }
+      const signature = await signWithNotification(EIP_712_TYPED_DATA__UPDATE_ENS);
 
       const response = await fetch(`/api/users/${address}/update-ens`, {
         method: "PUT",

--- a/packages/nextjs/hooks/useUpdateEns.ts
+++ b/packages/nextjs/hooks/useUpdateEns.ts
@@ -14,7 +14,9 @@ export function useUpdateEns() {
     mutationFn: async () => {
       if (!address) throw new Error("Wallet not connected");
 
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const signature = await signTypedDataAsync(EIP_712_TYPED_DATA__UPDATE_ENS);
+      notification.remove(loadingNotificationId);
 
       const response = await fetch(`/api/users/${address}/update-ens`, {
         method: "PUT",

--- a/packages/nextjs/hooks/useUpdateEns.ts
+++ b/packages/nextjs/hooks/useUpdateEns.ts
@@ -14,9 +14,13 @@ export function useUpdateEns() {
     mutationFn: async () => {
       if (!address) throw new Error("Wallet not connected");
 
+      let signature: `0x${string}` | undefined;
       const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      const signature = await signTypedDataAsync(EIP_712_TYPED_DATA__UPDATE_ENS);
-      notification.remove(loadingNotificationId);
+      try {
+        signature = await signTypedDataAsync(EIP_712_TYPED_DATA__UPDATE_ENS);
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       const response = await fetch(`/api/users/${address}/update-ens`, {
         method: "PUT",

--- a/packages/nextjs/hooks/useUpdateLocation.ts
+++ b/packages/nextjs/hooks/useUpdateLocation.ts
@@ -1,6 +1,7 @@
 import { useRouter } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
-import { useAccount, useSignTypedData } from "wagmi";
+import { useAccount } from "wagmi";
+import { useSignatureWithNotification } from "~~/hooks/useSignatureWithNotification";
 import { updateLocation } from "~~/services/api/users";
 import { UserLocation } from "~~/services/database/repositories/users";
 import { EIP_712_TYPED_DATA__UPDATE_LOCATION } from "~~/services/eip712/location";
@@ -9,7 +10,7 @@ import { notification } from "~~/utils/scaffold-eth";
 export const useUpdateLocation = ({ onSuccess }: { onSuccess?: () => void }) => {
   const router = useRouter();
   const { address } = useAccount();
-  const { signTypedDataAsync } = useSignTypedData();
+  const { signWithNotification } = useSignatureWithNotification();
 
   const { mutateAsync: updateLocationMutation, isPending } = useMutation({
     mutationFn: async (location: UserLocation) => {
@@ -20,16 +21,10 @@ export const useUpdateLocation = ({ onSuccess }: { onSuccess?: () => void }) => 
         location: location || "",
       };
 
-      let signature: `0x${string}` | undefined;
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      try {
-        signature = await signTypedDataAsync({
-          ...EIP_712_TYPED_DATA__UPDATE_LOCATION,
-          message,
-        });
-      } finally {
-        notification.remove(loadingNotificationId);
-      }
+      const signature = await signWithNotification({
+        ...EIP_712_TYPED_DATA__UPDATE_LOCATION,
+        message,
+      });
 
       return updateLocation({
         location: location || null,

--- a/packages/nextjs/hooks/useUpdateLocation.ts
+++ b/packages/nextjs/hooks/useUpdateLocation.ts
@@ -15,6 +15,7 @@ export const useUpdateLocation = ({ onSuccess }: { onSuccess?: () => void }) => 
     mutationFn: async (location: UserLocation) => {
       if (!address) throw new Error("Wallet not connected");
 
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__UPDATE_LOCATION.message,
         location: location || "",
@@ -24,6 +25,7 @@ export const useUpdateLocation = ({ onSuccess }: { onSuccess?: () => void }) => 
         ...EIP_712_TYPED_DATA__UPDATE_LOCATION,
         message,
       });
+      notification.remove(loadingNotificationId);
 
       return updateLocation({
         location: location || null,

--- a/packages/nextjs/hooks/useUpdateLocation.ts
+++ b/packages/nextjs/hooks/useUpdateLocation.ts
@@ -15,17 +15,21 @@ export const useUpdateLocation = ({ onSuccess }: { onSuccess?: () => void }) => 
     mutationFn: async (location: UserLocation) => {
       if (!address) throw new Error("Wallet not connected");
 
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__UPDATE_LOCATION.message,
         location: location || "",
       };
 
-      const signature = await signTypedDataAsync({
-        ...EIP_712_TYPED_DATA__UPDATE_LOCATION,
-        message,
-      });
-      notification.remove(loadingNotificationId);
+      let signature: `0x${string}` | undefined;
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
+      try {
+        signature = await signTypedDataAsync({
+          ...EIP_712_TYPED_DATA__UPDATE_LOCATION,
+          message,
+        });
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       return updateLocation({
         location: location || null,

--- a/packages/nextjs/hooks/useUpdateSocials.ts
+++ b/packages/nextjs/hooks/useUpdateSocials.ts
@@ -26,17 +26,21 @@ export const useUpdateSocials = ({ onSuccess }: { onSuccess?: () => void }) => {
         ...socials,
       };
 
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__UPDATE_SOCIALS.message,
         ...socialsWithDefaults,
       };
 
-      const signature = await signTypedDataAsync({
-        ...EIP_712_TYPED_DATA__UPDATE_SOCIALS,
-        message,
-      });
-      notification.remove(loadingNotificationId);
+      let signature: `0x${string}` | undefined;
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
+      try {
+        signature = await signTypedDataAsync({
+          ...EIP_712_TYPED_DATA__UPDATE_SOCIALS,
+          message,
+        });
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       return updateSocials({
         userAddress: address,

--- a/packages/nextjs/hooks/useUpdateSocials.ts
+++ b/packages/nextjs/hooks/useUpdateSocials.ts
@@ -26,6 +26,7 @@ export const useUpdateSocials = ({ onSuccess }: { onSuccess?: () => void }) => {
         ...socials,
       };
 
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__UPDATE_SOCIALS.message,
         ...socialsWithDefaults,
@@ -35,6 +36,7 @@ export const useUpdateSocials = ({ onSuccess }: { onSuccess?: () => void }) => {
         ...EIP_712_TYPED_DATA__UPDATE_SOCIALS,
         message,
       });
+      notification.remove(loadingNotificationId);
 
       return updateSocials({
         userAddress: address,

--- a/packages/nextjs/hooks/useUpdateUser.ts
+++ b/packages/nextjs/hooks/useUpdateUser.ts
@@ -24,6 +24,7 @@ export const useUpdateUser = ({ onSuccess }: { onSuccess?: () => void }) => {
     }) => {
       if (!address) throw new Error("Wallet not connected");
 
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__UPDATE_USER.message,
         userAddress,
@@ -36,6 +37,7 @@ export const useUpdateUser = ({ onSuccess }: { onSuccess?: () => void }) => {
         ...EIP_712_TYPED_DATA__UPDATE_USER,
         message,
       });
+      notification.remove(loadingNotificationId);
 
       const response = await fetch(`/api/users/${userAddress}/update`, {
         method: "PUT",

--- a/packages/nextjs/hooks/useUpdateUser.ts
+++ b/packages/nextjs/hooks/useUpdateUser.ts
@@ -24,7 +24,6 @@ export const useUpdateUser = ({ onSuccess }: { onSuccess?: () => void }) => {
     }) => {
       if (!address) throw new Error("Wallet not connected");
 
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const message = {
         ...EIP_712_TYPED_DATA__UPDATE_USER.message,
         userAddress,
@@ -33,11 +32,16 @@ export const useUpdateUser = ({ onSuccess }: { onSuccess?: () => void }) => {
         batchStatus: batchStatus || "",
       };
 
-      const signature = await signTypedDataAsync({
-        ...EIP_712_TYPED_DATA__UPDATE_USER,
-        message,
-      });
-      notification.remove(loadingNotificationId);
+      let signature: `0x${string}` | undefined;
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
+      try {
+        signature = await signTypedDataAsync({
+          ...EIP_712_TYPED_DATA__UPDATE_USER,
+          message,
+        });
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       const response = await fetch(`/api/users/${userAddress}/update`, {
         method: "PUT",

--- a/packages/nextjs/hooks/useUpdateUser.ts
+++ b/packages/nextjs/hooks/useUpdateUser.ts
@@ -1,6 +1,7 @@
 import { useRouter } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
-import { useAccount, useSignTypedData } from "wagmi";
+import { useAccount } from "wagmi";
+import { useSignatureWithNotification } from "~~/hooks/useSignatureWithNotification";
 import { BatchUserStatus, UserRole } from "~~/services/database/config/types";
 import { EIP_712_TYPED_DATA__UPDATE_USER } from "~~/services/eip712/users";
 import { notification } from "~~/utils/scaffold-eth";
@@ -8,7 +9,7 @@ import { notification } from "~~/utils/scaffold-eth";
 export const useUpdateUser = ({ onSuccess }: { onSuccess?: () => void }) => {
   const router = useRouter();
   const { address } = useAccount();
-  const { signTypedDataAsync } = useSignTypedData();
+  const { signWithNotification } = useSignatureWithNotification();
 
   const { mutate: updateUserMutation, isPending } = useMutation({
     mutationFn: async ({
@@ -32,16 +33,10 @@ export const useUpdateUser = ({ onSuccess }: { onSuccess?: () => void }) => {
         batchStatus: batchStatus || "",
       };
 
-      let signature: `0x${string}` | undefined;
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      try {
-        signature = await signTypedDataAsync({
-          ...EIP_712_TYPED_DATA__UPDATE_USER,
-          message,
-        });
-      } finally {
-        notification.remove(loadingNotificationId);
-      }
+      const signature = await signWithNotification({
+        ...EIP_712_TYPED_DATA__UPDATE_USER,
+        message,
+      });
 
       const response = await fetch(`/api/users/${userAddress}/update`, {
         method: "PUT",

--- a/packages/nextjs/hooks/useUserRegister.ts
+++ b/packages/nextjs/hooks/useUserRegister.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAccount, useSignTypedData } from "wagmi";
+import { useAccount } from "wagmi";
+import { useSignatureWithNotification } from "~~/hooks/useSignatureWithNotification";
 import { registerUser } from "~~/services/api/users";
 import { EIP_712_TYPED_DATA__USER_REGISTER } from "~~/services/eip712/register";
 import { notification } from "~~/utils/scaffold-eth";
@@ -7,7 +8,7 @@ import { notification } from "~~/utils/scaffold-eth";
 export function useUserRegister() {
   const { address } = useAccount();
   const queryClient = useQueryClient();
-  const { signTypedDataAsync } = useSignTypedData();
+  const { signWithNotification } = useSignatureWithNotification();
 
   const { mutateAsync: userLocationMutation, isPending: isRegistering } = useMutation({
     mutationFn: async ({
@@ -19,13 +20,7 @@ export function useUserRegister() {
     }) => {
       if (!address) throw new Error("Wallet not connected");
 
-      let signature: `0x${string}` | undefined;
-      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      try {
-        signature = await signTypedDataAsync(EIP_712_TYPED_DATA__USER_REGISTER);
-      } finally {
-        notification.remove(loadingNotificationId);
-      }
+      const signature = await signWithNotification(EIP_712_TYPED_DATA__USER_REGISTER);
 
       return registerUser({ address, signature, referrer, originalUtmParams });
     },

--- a/packages/nextjs/hooks/useUserRegister.ts
+++ b/packages/nextjs/hooks/useUserRegister.ts
@@ -25,7 +25,10 @@ export function useUserRegister() {
     if (!address) return;
 
     try {
+      const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
       const signature = await signTypedDataAsync(EIP_712_TYPED_DATA__USER_REGISTER);
+      notification.remove(loadingNotificationId);
+
       register({ address, signature, referrer, originalUtmParams });
     } catch (error) {
       console.error("Error during signature:", error);

--- a/packages/nextjs/hooks/useUserRegister.ts
+++ b/packages/nextjs/hooks/useUserRegister.ts
@@ -25,9 +25,13 @@ export function useUserRegister() {
     if (!address) return;
 
     try {
+      let signature: `0x${string}` | undefined;
       const loadingNotificationId = notification.loading("Awaiting for Wallet signature...");
-      const signature = await signTypedDataAsync(EIP_712_TYPED_DATA__USER_REGISTER);
-      notification.remove(loadingNotificationId);
+      try {
+        signature = await signTypedDataAsync(EIP_712_TYPED_DATA__USER_REGISTER);
+      } finally {
+        notification.remove(loadingNotificationId);
+      }
 
       register({ address, signature, referrer, originalUtmParams });
     } catch (error) {


### PR DESCRIPTION
This PR aim to do 2 things:

### 1. Better UX on loading states

- Show notification. Loading when waiting for wallet signature. This is feedback I got from @escottalexander, who was connected with Wallet Connect and trying to submit a challenge, and since the text just said "submitting..", he was waiting for the submission to complete (forgetting the signature in his phone). This can also happen when MM is buggy and doesn't open.
- Always show a spinner as loading text (instead of text or spinner + text) to be consistent

<img width="1343" height="1235" alt="image" src="https://github.com/user-attachments/assets/48efd57e-9d66-41ff-b7e0-3698df74c7ae" />

### 2. Consistency on hooks

There were some hooks (like `useUserRegister`) that weren't returning the `isLoading` properly (because it had a `handle` function that was awaiting the mutation. I refactor these so we directly return the mutation function


-----

### Misc

- Grabbing the UTM params / referer when registering for other places that are not the header/homepage.
