### PR TITLE
Bigger PunkBlockie. Show XP points

### DIFF
--- a/packages/nextjs/app/api/og/route.tsx
+++ b/packages/nextjs/app/api/og/route.tsx
@@ -2,11 +2,7 @@
 import { ImageResponse } from "next/og";
 import { blo } from "blo";
 import { getAddress, isAddress } from "viem";
-import { ReviewAction } from "~~/services/database/config/types";
-import {
-  UserChallenges,
-  getLatestSubmissionPerChallengeByUser,
-} from "~~/services/database/repositories/userChallenges";
+import { getUserXP } from "~~/services/database/repositories/users";
 import { getShortAddressAndEns } from "~~/utils/short-address-and-ens";
 
 export async function GET(request: Request) {
@@ -21,14 +17,8 @@ export async function GET(request: Request) {
     const checksumAddress = getAddress(address);
 
     const { ensName, ensAvatar, shortAddress } = await getShortAddressAndEns(checksumAddress);
+    const userXP = await getUserXP(checksumAddress);
 
-    let challenges: UserChallenges = [];
-    try {
-      const allChallenges = await getLatestSubmissionPerChallengeByUser(address);
-      challenges = allChallenges.filter(challenge => challenge.reviewAction === ReviewAction.ACCEPTED);
-    } catch (error) {
-      console.error("Error fetching builder challenges", error);
-    }
     // punk size with scale = 1
     const PUNK_SIZE = 112;
     // punk size pixels in the original file
@@ -40,7 +30,7 @@ export async function GET(request: Request) {
     const backgroundPositionX = parseInt(part1, 16) % 100;
     const backgroundPositionY = parseInt(part2, 16) % 100;
 
-    const computedScale = 1;
+    const computedScale = 1.7;
 
     // Get the Punks image from the live site
     const baseUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
@@ -151,8 +141,8 @@ export async function GET(request: Request) {
                   marginTop: 30,
                   display: "flex",
                   overflow: "hidden",
-                  width: 117,
-                  height: 117,
+                  width: 200,
+                  height: 200,
                   borderRadius: "50%",
                   borderWidth: 5,
                   borderColor: "white",
@@ -200,12 +190,12 @@ export async function GET(request: Request) {
               style={{
                 marginTop: 5,
                 display: "flex",
-                fontSize: 28,
+                fontSize: 36,
                 textAlign: "center",
                 color: "#4a5565",
               }}
             >
-              Challenges Completed: {challenges.length}
+              {userXP} XP
             </div>
           </div>
 

--- a/packages/nextjs/app/builders/[address]/page.tsx
+++ b/packages/nextjs/app/builders/[address]/page.tsx
@@ -11,7 +11,7 @@ import { getBatchById } from "~~/services/database/repositories/batches";
 import { getBuildsByUserAddress } from "~~/services/database/repositories/builds";
 import { getAllChallenges } from "~~/services/database/repositories/challenges";
 import { getLatestSubmissionPerChallengeByUser } from "~~/services/database/repositories/userChallenges";
-import { getUserByAddress, getUserPoints } from "~~/services/database/repositories/users";
+import { getUserByAddress, getUserXP } from "~~/services/database/repositories/users";
 import { getShortAddressAndEns } from "~~/utils/short-address-and-ens";
 import { getTotalXP } from "~~/utils/xp";
 
@@ -77,7 +77,7 @@ export default async function BuilderPage(props: { params: Promise<{ address: st
     userBatch = await getBatchById(user.batchId);
   }
   const builds = await getBuildsByUserAddress(address);
-  const points = await getUserPoints(address);
+  const points = await getUserXP(address);
 
   if (!user) {
     notFound();

--- a/packages/nextjs/services/database/repositories/users.ts
+++ b/packages/nextjs/services/database/repositories/users.ts
@@ -251,7 +251,7 @@ export async function filterValidUserAddresses(addresses: string[]): Promise<str
   return rows.map(row => row.userAddress);
 }
 
-export async function getUserPoints(userAddress: string) {
+export async function getUserXP(userAddress: string) {
   const lowercaseAddress = userAddress.toLowerCase();
 
   const user = await db.query.users.findFirst({


### PR DESCRIPTION
Little tweaks to the unfurl image after some feedback from Austin:

- Bigger PunkBlockie (to match the size - 200 - of the ENS Avatar)
- Show XP instead of Challenge completed

<img width="471" height="325" alt="image" src="https://github.com/user-attachments/assets/54262524-dc14-4223-8961-f86dcf3f3aad" />

<img width="465" height="315" alt="image" src="https://github.com/user-attachments/assets/f3b36138-6b32-4780-81bd-60117c8a0dc4" />

I also renamed the `getUserPoints` function to `getUserXP`.

----

Tested it with the oGraph Preview extensions
