### PR TITLE
Fix XP overcount by excluding _lastCheckedAt from side quest count

### DIFF
--- a/packages/nextjs/services/database/repositories/users.ts
+++ b/packages/nextjs/services/database/repositories/users.ts
@@ -271,7 +271,10 @@ export async function getUserXP(userAddress: string) {
   const hasBuilds = user?.buildBuilders && user?.buildBuilders.length > 0;
 
   const challengePoints = acceptedNonDisabledChallengesCount * CHALLENGE_XP;
-  const sideQuestPoints = Object.keys(user?.sideQuestsSnapshot || {}).length * SIDE_QUEST_XP;
+  const completedSideQuestsCount = Object.keys(user?.sideQuestsSnapshot || {}).filter(
+    key => key !== "_lastCheckedAt",
+  ).length;
+  const sideQuestPoints = completedSideQuestsCount * SIDE_QUEST_XP;
   const batchPoints = hasBatch ? BATCH_XP : 0;
   const buildPoints = hasBuilds ? BUILD_XP : 0;
 


### PR DESCRIPTION
Chosen approach (simplicity): Exclude the `_lastCheckedAt` key when counting side quests from `sideQuestsSnapshot`.

If we want a more robust approach we could iterate over `SIDEQUEST_IDS` and count only entries that have a `completedAt` timestamp. This guards against any future metadata keys being added to the snapshot, but we're probably fine with the simplest approach?

For example on my user, it should show 75 (staging) instead of 80 (prod): 0xB4F53bd85c00EF22946d24Ae26BC38Ac64F5E7B1

Fixes #331 

