### PR TITLE
Fix font color for How is XP calculated modal item titles

### DIFF
--- a/packages/nextjs/app/builders/[address]/_components/PointsBar.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/PointsBar.tsx
@@ -32,7 +32,7 @@ const PointsBarModal = forwardRef<HTMLDialogElement, PointsBarModalProps>(({ clo
           <dl className="mt-5 grid grid-cols-1 divide-gray-200 overflow-hidden rounded-lg bg-base-100 border border-gray-200 md:grid-cols-4 md:divide-x divide-y md:divide-y-0">
             {stats.map(item => (
               <div key={item.name} className="px-4 py-5 sm:p-6">
-                <dt className="text-base font-normal text-gray-500">{item.name}</dt>
+                <dt className="text-base font-normal text-base-content">{item.name}</dt>
                 <dd className="mt-1 flex items-baseline justify-between md:block lg:flex">
                   <div className="flex items-baseline text-2xl font-semibold text-primary">{item.stat}</div>
                 </dd>


### PR DESCRIPTION
Fixes #333 

Previous:
<img width="1271" height="269" alt="image" src="https://github.com/user-attachments/assets/63cdd04c-eab1-4bf6-9d8a-c0528f3172c1" />
<img width="898" height="242" alt="image" src="https://github.com/user-attachments/assets/26caeafb-d7fa-4a12-8bcb-6459989dac45" />

New:
<img width="891" height="246" alt="image" src="https://github.com/user-attachments/assets/6f507842-51eb-4de8-993e-7e06c848c05d" />
<img width="895" height="238" alt="image" src="https://github.com/user-attachments/assets/678e2cd1-8e67-467e-8fb4-a308b4f310ad" />
