### PR TITLE
Shorten /start page CTA to fix display when wallet not connected

### DIFF
--- a/packages/nextjs/app/start/_components/ProgressBasedPrompt.tsx
+++ b/packages/nextjs/app/start/_components/ProgressBasedPrompt.tsx
@@ -25,7 +25,7 @@ export const ProgressBasedPrompt = () => {
           <>
             <p className="mt-0 mb-1 text-center lg:text-left md:text-lg">Already comfortable building on Ethereum?</p>
             <Link href="/challenge/tokenization" className="link">
-              Jump straight to the first challenge
+              Jump to the first challenge
             </Link>
           </>
         )}


### PR DESCRIPTION
Change `ProgressBasedPrompt` link text to “Jump to the first challenge” so the CTA stays on one line on /start when there is no user connected.

<img width="337" height="175" alt="image" src="https://github.com/user-attachments/assets/2f33f901-d9ad-41b0-b14f-5054448f20bf" />

Fixes #341 