### PR TITLE
Standardize naming to 'Speedrun Ethereum'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# SpeedRunEthereum
+# Speedrun Ethereum
 
 ![SRE Thumbnail](./packages/nextjs/public/thumbnail.png)
 
-New version of [SpeedRunEthereum](https://github.com/BuidlGuidl/SpeedRunEthereum) built with [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2). An expanded experience for builders where you'll be able to unlock your builder profile after completing a few challenges. This will open the gates to:
+New version of [Speedrun Ethereum](https://github.com/BuidlGuidl/SpeedRunEthereum) built with [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2). An expanded experience for builders where you'll be able to unlock your builder profile after completing a few challenges. This will open the gates to:
 
 - Interact with other BuidlGuidl curriculums like [ETH Tech Tree](https://www.ethtechtree.com/) and [BuidlGuidl CTF](https://ctf.buidlguidl.com/)
 - Share your builds and discover what other builders are up to

--- a/packages/nextjs/app/builds/page.tsx
+++ b/packages/nextjs/app/builds/page.tsx
@@ -4,7 +4,7 @@ import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
 export const metadata = getMetadata({
   title: "All Builds",
-  description: "View all the builds by the Speed Run Ethereum community",
+  description: "View all the builds by the Speedrun Ethereum community",
 });
 
 export default async function AllBuildsPage(props: {

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ConnectAndRegisterBanner.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ConnectAndRegisterBanner.tsx
@@ -35,7 +35,7 @@ export const ConnectAndRegisterBanner = () => {
                 </p>
                 <p>
                   <span className="font-bold">Connect your wallet and register</span> to unlock the full
-                  SpeedRunEthereum experience.
+                  Speedrun Ethereum experience.
                 </p>
               </>
             ) : (

--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -13,7 +13,7 @@ const spaceGrotesk = Space_Grotesk({
 });
 
 export const metadata = getMetadata({
-  title: "Speed Run Ethereum",
+  title: "Speedrun Ethereum",
   description: "Learn Solidity development to build dapps on Ethereum with hands-on blockchain challenges.",
 });
 

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -4,7 +4,7 @@ import { getAllChallenges } from "~~/services/database/repositories/challenges";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
 export const metadata = getMetadata({
-  title: "Speed Run Ethereum: Learn Solidity Development Through Interactive Challenges",
+  title: "Speedrun Ethereum: Learn Solidity Development Through Interactive Challenges",
   description:
     "Learn Solidity development with hands-on blockchain challenges. Build NFTs, DEXs, and more Ethereum smart contracts in our step-by-step tutorial series.",
 });

--- a/packages/nextjs/app/start/page.tsx
+++ b/packages/nextjs/app/start/page.tsx
@@ -56,7 +56,7 @@ const StartLandingPage = async () => {
           </div>
           <div className="max-w-3xl mx-auto">
             <p className="my-10 text-lg md:my-14 md:text-center md:text-xl md:leading-relaxed">
-              SpeedRunEthereum is a <TargetIcon className="inline-block w-6 h-6" /> hands-on series of challenges
+              Speedrun Ethereum is a <TargetIcon className="inline-block w-6 h-6" /> hands-on series of challenges
               designed to help you <strong>learn by building</strong>. Each challenge delivers one key "aha" moment,{" "}
               <LightbulbIcon className="inline-block w-6 h-6" /> a mental unlock about how{" "}
               <MachineIcon className="inline-block w-6 h-6" /> Ethereum really works. At the same time, you'll be
@@ -134,14 +134,14 @@ const StartLandingPage = async () => {
         <div className="relative z-10 max-w-4xl mx-auto px-6 text-lg lg:pb-12">
           <div className="mb-12 flex flex-col items-center gap-4 lg:flex-row lg:gap-4 lg:justify-center">
             <ToolsIcon />
-            <h2 className="m-0 text-center text-2xl font-medium md:text-4xl">How does SpeedRunEthereum work?</h2>
+            <h2 className="m-0 text-center text-2xl font-medium md:text-4xl">How does Speedrun Ethereum work?</h2>
           </div>
           <p>
             You'll be able to <strong>tinker with smart contracts</strong>, deploy locally, test interactions, and build
             usable decentralized apps from day one.
           </p>
           <p>
-            Along the way, you can submit completed challenges to your SpeedRunEthereum portfolio. Each challenge
+            Along the way, you can submit completed challenges to your Speedrun Ethereum portfolio. Each challenge
             becomes a public proof of your learning.
           </p>
           <p className="mt-8 mb-4">

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -40,7 +40,7 @@ export const queryClient = new QueryClient({
 });
 
 const getSiweMessageOptions: GetSiweMessageOptions = () => ({
-  statement: "Sign in to SpeedRunEthereum",
+  statement: "Sign in to Speedrun Ethereum",
 });
 
 export const ScaffoldEthAppWithProviders = ({ children }: { children: React.ReactNode }) => {

--- a/packages/nextjs/guides/erc-4626-vaults.md
+++ b/packages/nextjs/guides/erc-4626-vaults.md
@@ -283,4 +283,4 @@ function _accrueFees(uint256 realizedGainAssets) internal {
 - Understand LP risks: [Impermanent Loss Explained](/guides/impermanent-loss-math-explained)
 - Build tokens first: [How to Create an ERC20 Token](/guides/how-to-create-erc20)
 
-Ready to practice? Try the [Decentralized Staking Challenge](/challenge/decentralized-staking) in SpeedRunEthereum.
+Ready to practice? Try the [Decentralized Staking Challenge](/challenge/decentralized-staking) in Speedrun Ethereum.

--- a/packages/nextjs/guides/how-to-create-erc20.md
+++ b/packages/nextjs/guides/how-to-create-erc20.md
@@ -201,7 +201,7 @@ _Figure: Six-step chain process for building secure and transparent tokens, from
 
 🚀 **Ready to apply this knowledge?**
 
-The ERC20 token you've designed is the perfect starting point for more advanced challenges on SpeedRunEthereum:
+The ERC20 token you've designed is the perfect starting point for more advanced challenges on Speedrun Ethereum:
 
 - [**Token Vendor Challenge**](https://speedrunethereum.com/challenge/token-vendor)**:** Take the token you just conceptualized and build a TokenVendor.sol smart contract. This vendor will act like a vending machine, selling your ERC20 tokens to users in exchange for ETH.
 - [**Minimum Viable Exchange (DEX) Challenge**](https://speedrunethereum.com/challenge/dex)**:** Go even further by building a basic decentralized exchange. Users will be able to trade ETH for your token and your token back for ETH, learning about liquidity provision and automated market-making concepts.

--- a/packages/nextjs/services/database/seed.data.example.ts
+++ b/packages/nextjs/services/database/seed.data.example.ts
@@ -320,7 +320,7 @@ export const seedUserChallenges: (typeof userChallenges.$inferInsert)[] = [
     contractUrl: "https://sepolia-optimism.etherscan.io/address/0xad5e878a62D5B77277aCDC321614a9727815B4C8#code",
     submittedAt: new Date(1736441361988),
     reviewComment:
-      "<p>You have successfully passed challenge 2!</p><p>You have passed the first three challenges on SpeedRunEthereum and can now join the BuidlGuidl!</p>",
+      "<p>You have successfully passed challenge 2!</p><p>You have passed the first three challenges on Speedrun Ethereum and can now join the BuidlGuidl!</p>",
     reviewAction: ReviewAction.REJECTED,
   },
   {

--- a/packages/nextjs/services/eip712/common.ts
+++ b/packages/nextjs/services/eip712/common.ts
@@ -1,7 +1,7 @@
 import { RecoverTypedDataAddressParameters, recoverTypedDataAddress } from "viem";
 
 export const EIP_712_DOMAIN = {
-  name: "SpeedRunEthereum",
+  name: "Speedrun Ethereum",
   version: "1",
   chainId: 1,
   verifyingContract: "0x0000000000000000000000000000000000000000",

--- a/packages/nextjs/utils/scaffold-eth/getMetadata.ts
+++ b/packages/nextjs/utils/scaffold-eth/getMetadata.ts
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 const baseUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
   : `http://localhost:${process.env.PORT || 3000}`;
-const titleTemplate = "%s | Speed Run Ethereum";
+const titleTemplate = "%s | Speedrun Ethereum";
 
 export const getMetadata = ({
   title,


### PR DESCRIPTION
Replace inconsistent variations (SpeedRunEthereum, SpeedRun Ethereum, Speed Run Ethereum) with the standardized form 'Speedrun Ethereum'.

Preserved:
- speedrunethereum.com domain
- Repository URLs
- Lowercase references in links