### PR TITLE
Improve token vesting prompt

### DIFF
--- a/packages/nextjs/build-prompts/token-vesting.md
+++ b/packages/nextjs/build-prompts/token-vesting.md
@@ -7,18 +7,21 @@ imageUrl: "/assets/build-prompts/token-vesting.png"
 # SPEC: Token Vesting Schedule
 
 ## 1. Objective
+
 A continuous payment system where a team member's or investor's tokens are unlocked linearly over time to prevent sudden market dumping.
 
 ## 2. Pre-flight & Context
+
 - **Framework:** Scaffold-ETH 2.
 - **Check:** Verify if ./packages/nextjs/scaffold.config.ts exists directly in the current working directory (do not search subdirectories). If it doesn't exist, this is not a Scaffold-ETH 2 project. Follow the instructions at https://docs.scaffoldeth.io/SKILL.md to scaffold it first. If it exists, continue directly with building.
 
 ## 3. Builder Customizations (Tweak before prompting)
-- `DEFAULT_DURATION_DAYS`: 365
-- `ADMIN_ADDRESS`: *(optional)* If set, this address becomes the owner of the TokenVesting contract. If not set, defaults to the deployer (`msg.sender`).
+
+- `ADMIN_ADDRESS`: _(optional)_ If set, this address becomes the owner of the TokenVesting contract. If not set, defaults to the deployer (`msg.sender`).
 - `UI_THEME`: Corporate, clean, transparent team dashboard.
 
 ## 4. Smart Contract Spec
+
 - **Architecture:** Vesting schedules mapping beneficiaries to total amount, start time, duration, and claimed amounts.
 - **Admin Configuration:** The `TokenVesting` constructor must accept an `_admin` address parameter and pass it to `Ownable(_admin)`. The deploy script should use `ADMIN_ADDRESS` from Builder Customizations if provided; otherwise default to the deployer address.
 - **Test Token Minting:** The `VestingToken` `mint()` function should be open (no `onlyOwner`) so anyone can mint test tokens to try the app.
@@ -26,12 +29,18 @@ A continuous payment system where a team member's or investor's tokens are unloc
 - **Agent Autonomy:** Handle the precision math for linear unlocking cleanly. Decide how to track multiple vesting schedules efficiently.
 
 ## 5. Frontend Spec
-- **Required Views:** Admin view to create schedules. Employee view visualizing their personal vesting schedule.
+
+- **Required Views:** Admin view to create schedules. Employee view visualizing their personal vesting schedule (show starting vesting date and time). Allow to create vesting schedules for minutes, hours, or days (default to 365 days). Allow to create vesting schedules starting in a future date and time, too.
 - **Owner Check:** The admin page must check ownership against the `TokenVesting` contract's `owner()`, NOT the `VestingToken` contract's `owner()`. These are different contracts with potentially different owners.
 - **Auto-Approval Flow:** When creating a vesting schedule, the frontend must first call `VestingToken.approve(vestingContractAddress, maxUint256)` before calling `createSchedule()`, since `createSchedule` uses `transferFrom` internally. Without this, users will hit an `ERC20InsufficientAllowance` error.
 - **Agent Autonomy:** Build the `UI_THEME` utilizing a visual "progress bar" using Tailwind CSS to cleanly indicate locked vs. unlocked vs. claimed tokens.
 
-## 6. Next Iterations (Builder: ask the agent to add these later)
+## 6. Review
+
+- Always review the generated code and use the grumpy-carlos-code-reviewer agent for that.
+
+## 7. Next Iterations (Builder: ask the agent to add these later)
+
 - [ ] Revocable streams (admin can cancel future unvested tokens).
 - [ ] Cliff periods (no tokens unlock until X months pass).
 - [ ] Multi-beneficiary batch creation.


### PR DESCRIPTION
Tested with Sonnet 4.6, Composer 2, and GPT 5.4.

The Solidity code works well and looks good, but the frontend depends on the model used. Added some instructions so the frontend features do not depend on the model.

Added shorter vesting period on the frontend for better manual testing, too.