### PR TITLE
fix impermanent loss price ratio derivation in guide

### DIFF
--- a/packages/nextjs/guides/impermanent-loss-math-explained.md
+++ b/packages/nextjs/guides/impermanent-loss-math-explained.md
@@ -63,14 +63,14 @@ The impermanent loss formula can be derived from first principles:
 **Step 1: Define Initial State**
 
 - Initial quantities: `x₀`, `y₀`
-- Initial price ratio: `p₀ = x₀/y₀`
+- Initial price ratio (price of token `x` in units of token `y`): `p₀ = y₀/x₀`
 - Invariant: `k = x₀ × y₀`
 
 **Step 2: After Price Change**
 
 - New price ratio: `p₁`
 - New quantities: `x₁`, `y₁`
-- Still: `k = x₁ × y₁` and `p₁ = x₁/y₁`
+- Still: `k = x₁ × y₁` and `p₁ = y₁/x₁`
 
 **Step 3: Solve for New Quantities**
 From the equations above:

--- a/packages/nextjs/guides/impermanent-loss-math-explained.md
+++ b/packages/nextjs/guides/impermanent-loss-math-explained.md
@@ -68,7 +68,7 @@ The impermanent loss formula can be derived from first principles:
 
 **Step 2: After Price Change**
 
-- New price ratio: `p₁`
+- New price ratio (same convention, price of `x` in units of `y`): `p₁`
 - New quantities: `x₁`, `y₁`
 - Still: `k = x₁ × y₁` and `p₁ = y₁/x₁`
 


### PR DESCRIPTION
## Summary
- correct the price ratio definition from `x/y` to `y/x` in the impermanent loss derivation
- align the initial and post-price-change equations with the later reserve and valuation formulas

## Why
The guide later uses `x₁ = √(k/p₁)`, `y₁ = √(k × p₁)`, and `Value_LP = y₁ + (x₁ × p₁)`, which all imply that `p` is the price of token `x` in units of token `y` (`p = y/x`).