### PR TITLE
AI chat tweaks: heading line-height + retry on empty/failed responses

### DIFF
--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/ChatMessage.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/ChatMessage.tsx
@@ -62,6 +62,12 @@ type ChatMessageProps = {
 };
 
 export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
+  const hasText = message.parts.some(p => p.type === "text" && p.text.trim().length > 0);
+
+  // Hide empty assistant bubbles that aren't actively streaming — these are failed/empty
+  // responses; the parent renders a retry control instead.
+  if (message.role === "assistant" && !hasText && !isStreaming) return null;
+
   return (
     <div className={`chat ${message.role === "user" ? "chat-end" : "chat-start"}`}>
       {message.role === "assistant" && (

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/ChatMessage.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/ChatMessage.tsx
@@ -64,8 +64,6 @@ type ChatMessageProps = {
 export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
   const hasText = message.parts.some(p => p.type === "text" && p.text.trim().length > 0);
 
-  // Hide empty assistant bubbles that aren't actively streaming — these are failed/empty
-  // responses; the parent renders a retry control instead.
   if (message.role === "assistant" && !hasText && !isStreaming) return null;
 
   return (

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
@@ -6,7 +6,14 @@ import { ChatMessage } from "./ChatMessage";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { useStickToBottom } from "use-stick-to-bottom";
-import { ArrowDownIcon, ArrowPathIcon, PaperAirplaneIcon, SparklesIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import {
+  ArrowDownIcon,
+  ArrowPathIcon,
+  ExclamationTriangleIcon,
+  PaperAirplaneIcon,
+  SparklesIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
 import { useAuthSession } from "~~/hooks/useAuthSession";
 
 type ChatWidgetProps = {
@@ -202,25 +209,13 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
               )}
 
               {error && (
-                <div className="alert bg-error/10 border border-error/20 text-error text-sm rounded-xl mx-1 flex items-center gap-2">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="stroke-current shrink-0 h-5 w-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
-                  <span className="flex-1">Something went wrong.</span>
+                <div className="flex items-center gap-2.5 py-2 px-3 rounded-xl border border-error/25 bg-error/5 dark:bg-error/10">
+                  <ExclamationTriangleIcon className="w-4 h-4 text-error shrink-0" />
+                  <span className="flex-1 text-[13px] text-error">Connection failed.</span>
                   <button
                     type="button"
                     onClick={handleRetry}
-                    className="btn btn-xs btn-ghost text-error hover:bg-error/10 gap-1"
+                    className="inline-flex items-center gap-1 text-error font-medium text-[13px] hover:bg-error/10 rounded-full px-2 py-0.5 transition-colors"
                     aria-label="Retry"
                   >
                     <ArrowPathIcon className="w-3.5 h-3.5" />
@@ -230,14 +225,15 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
               )}
 
               {responseMissing && (
-                <div className="flex items-center gap-2 text-xs text-base-content/60 px-1">
-                  <span>No response received.</span>
+                <div className="flex items-center gap-2.5 py-2 px-3 rounded-xl border border-base-content/10 bg-base-200/40 dark:bg-[#1a2236]/40">
+                  <span className="flex-1 text-[13px] text-base-content/70">Nothing came back.</span>
                   <button
                     type="button"
                     onClick={handleRetry}
-                    className="inline-flex items-center gap-1 text-primary hover:underline"
+                    className="inline-flex items-center gap-1 text-primary font-medium text-[13px] hover:bg-primary/10 rounded-full px-2 py-0.5 transition-colors"
+                    aria-label="Retry"
                   >
-                    <ArrowPathIcon className="w-3 h-3" />
+                    <ArrowPathIcon className="w-3.5 h-3.5" />
                     Retry
                   </button>
                 </div>

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
@@ -85,11 +85,13 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
   };
 
   const lastMessage = messages[messages.length - 1];
-  const lastIsEmptyAssistant =
+  const responseMissing =
     !isStreaming &&
     !error &&
-    lastMessage?.role === "assistant" &&
-    !lastMessage.parts.some(p => p.type === "text" && p.text.trim().length > 0);
+    messages.length > 0 &&
+    (lastMessage?.role === "user" ||
+      (lastMessage?.role === "assistant" &&
+        !lastMessage.parts.some(p => p.type === "text" && p.text.trim().length > 0)));
 
   // Auto-resize textarea
   useEffect(() => {
@@ -227,7 +229,7 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
                 </div>
               )}
 
-              {lastIsEmptyAssistant && (
+              {responseMissing && (
                 <div className="flex items-center gap-2 text-xs text-base-content/60 px-1">
                   <span>No response received.</span>
                   <button

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
@@ -34,7 +34,7 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
     [challengeId, github],
   );
 
-  const { messages, sendMessage, setMessages, status, error } = useChat({ transport });
+  const { messages, sendMessage, setMessages, status, error, regenerate, clearError } = useChat({ transport });
 
   // Track when we've submitted but status may not have caught up yet.
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -76,6 +76,20 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
     setMessages([]);
     setIsSubmitting(false);
   };
+
+  const handleRetry = async () => {
+    if (error) clearError();
+    setIsSubmitting(true);
+    scrollToBottom();
+    await regenerate();
+  };
+
+  const lastMessage = messages[messages.length - 1];
+  const lastIsEmptyAssistant =
+    !isStreaming &&
+    !error &&
+    lastMessage?.role === "assistant" &&
+    !lastMessage.parts.some(p => p.type === "text" && p.text.trim().length > 0);
 
   // Auto-resize textarea
   useEffect(() => {
@@ -164,8 +178,12 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
                 />
               )}
 
-              {messages.map(message => (
-                <ChatMessage key={message.id} message={message} isStreaming={isStreaming} />
+              {messages.map((message, idx) => (
+                <ChatMessage
+                  key={message.id}
+                  message={message}
+                  isStreaming={isStreaming && idx === messages.length - 1}
+                />
               ))}
 
               {isStreaming && messages[messages.length - 1]?.role === "user" && (
@@ -182,7 +200,7 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
               )}
 
               {error && (
-                <div className="alert bg-error/10 border border-error/20 text-error text-sm rounded-xl mx-1">
+                <div className="alert bg-error/10 border border-error/20 text-error text-sm rounded-xl mx-1 flex items-center gap-2">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     className="stroke-current shrink-0 h-5 w-5"
@@ -196,7 +214,30 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
                       d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
                     />
                   </svg>
-                  <span>Something went wrong. Please try again.</span>
+                  <span className="flex-1">Something went wrong.</span>
+                  <button
+                    type="button"
+                    onClick={handleRetry}
+                    className="btn btn-xs btn-ghost text-error hover:bg-error/10 gap-1"
+                    aria-label="Retry"
+                  >
+                    <ArrowPathIcon className="w-3.5 h-3.5" />
+                    Retry
+                  </button>
+                </div>
+              )}
+
+              {lastIsEmptyAssistant && (
+                <div className="flex items-center gap-2 text-xs text-base-content/60 px-1">
+                  <span>No response received.</span>
+                  <button
+                    type="button"
+                    onClick={handleRetry}
+                    className="inline-flex items-center gap-1 text-primary hover:underline"
+                  >
+                    <ArrowPathIcon className="w-3 h-3" />
+                    Retry
+                  </button>
                 </div>
               )}
             </div>

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -124,6 +124,13 @@ p {
   font-size: 13px;
 }
 
+.chat-prose-compact .prose h1,
+.chat-prose-compact .prose h2,
+.chat-prose-compact .prose h3,
+.chat-prose-compact .prose h4 {
+  line-height: 1.3;
+}
+
 .chat-prose-compact .prose h1 {
   font-size: 16px;
 }


### PR DESCRIPTION
Picking off two items from #379:

<details>

<summary>
chatbot's h2 line-height was tight enough that wrapped headings looked like two separate sentences    
</summary>

<img width="413" height="304" alt="image" src="https://github.com/user-attachments/assets/1eded72c-b92d-4e58-bf8b-3b8a2dc05aac" />


</details>


<details>

<summary>
empty or failed responses had no recovery, the user just saw their message and silence     
</summary>

<img width="410" height="183" alt="image" src="https://github.com/user-attachments/assets/8ce3f29e-a494-442d-b448-c2ff8c4ccaff" />


</details>




## Test plan

- [ ] H2 line-height: trigger a chatbot response with a wrapped heading, the lines should breathe
- [ ] Error retry: DevTools → Network → block `/api/chat` → send a message → red alert with Retry
- [ ] Empty retry: temporarily short-circuit `app/api/chat/route.ts` to return an empty UI message stream via `createUIMessageStream` → soft pill appears → Retry re-runs the last turn