### PR TITLE
/builds sort and add header link

### DIFF
--- a/packages/nextjs/app/api/builds/route.ts
+++ b/packages/nextjs/app/api/builds/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest } from "next/server";
 import { BuildCategory, BuildType } from "~~/services/database/config/types";
-import { getAllBuilds } from "~~/services/database/repositories/builds";
+import { BuildSort, BuildSortDirection, getAllBuilds } from "~~/services/database/repositories/builds";
+
+const ALLOWED_SORTS: BuildSort[] = ["likes", "name", "date"];
+const ALLOWED_DIRECTIONS: BuildSortDirection[] = ["asc", "desc"];
 
 export async function GET(request: NextRequest) {
   try {
@@ -8,12 +11,18 @@ export async function GET(request: NextRequest) {
     const category = searchParams.get("category");
     const type = searchParams.get("type");
     const nameSearch = searchParams.get("name");
+    const sortParam = searchParams.get("sort") as BuildSort | null;
+    const directionParam = searchParams.get("direction") as BuildSortDirection | null;
+    const sort = sortParam && ALLOWED_SORTS.includes(sortParam) ? sortParam : undefined;
+    const direction = directionParam && ALLOWED_DIRECTIONS.includes(directionParam) ? directionParam : undefined;
     const start = Number(searchParams.get("start") || 0);
     const size = Number(searchParams.get("size") || 48);
     const data = await getAllBuilds({
       category: category ? (category as BuildCategory) : undefined,
       type: type ? (type as BuildType) : undefined,
       nameSearch: nameSearch || undefined,
+      sort,
+      direction,
       start,
       size,
     });

--- a/packages/nextjs/app/builders/[address]/_components/UserProfileCard.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/UserProfileCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { UserLocation } from "./UserLocation";
 import { UserNotesIndicator } from "./UserNotesIndicator";
 import { UserSocials } from "./UserSocials";
@@ -20,16 +21,26 @@ type UserProfileCardProps = {
 
 export const UserProfileCard = ({ user, batch }: UserProfileCardProps) => {
   const { isAdmin } = useAuthSession();
+  const [avatarErrored, setAvatarErrored] = useState(false);
+
+  useEffect(() => {
+    setAvatarErrored(false);
+  }, [user.ensAvatar]);
 
   return (
     <>
       <div className="bg-base-100 rounded-lg p-6">
         <div className="flex flex-col md:flex-row justify-around lg:flex-col items-center gap-4">
           <div className="relative">
-            {user.ensAvatar ? (
+            {user.ensAvatar && !avatarErrored ? (
               <div className="w-[224px] h-[224px] relative">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={user.ensAvatar} alt={user.userAddress} className="absolute inset-0" />
+                <img
+                  src={user.ensAvatar}
+                  alt={user.userAddress}
+                  className="absolute inset-0"
+                  onError={() => setAvatarErrored(true)}
+                />
               </div>
             ) : (
               <PunkBlockie address={user.userAddress} scale={2} />

--- a/packages/nextjs/app/builders/[address]/_components/builds/BuildCard.tsx
+++ b/packages/nextjs/app/builders/[address]/_components/builds/BuildCard.tsx
@@ -4,6 +4,7 @@ import { DeleteBuildButton } from "./DeleteBuildButton";
 import { EditBuildButton } from "./EditBuildButton";
 import { LikeBuildButton } from "./LikeBuildButton";
 import { Build } from "~~/services/database/repositories/builds";
+import { formatShortDate } from "~~/utils/date";
 
 type Props = {
   ownerAddress: string;
@@ -46,9 +47,10 @@ export const BuildCard = ({ ownerAddress, build, likes, coBuilders }: Props) => 
         )}
       </div>
       <div className="flex flex-col flex-1 px-6 py-4">
-        <div className="flex items-start gap-2 mb-2">
-          <h2 className="text-xl font-bold leading-tight line-clamp-2 flex-1 min-w-0">{build.name}</h2>
+        <div className="flex items-start gap-2">
+          <h2 className="m-0 text-xl font-bold leading-tight line-clamp-2 flex-1 min-w-0">{build.name}</h2>
         </div>
+        <p className="mt-1 mb-2 text-xs text-neutral">{formatShortDate(build.submittedTimestamp)}</p>
         <p className="text-sm my-1 line-clamp-4">{build.desc}</p>
         <div className="flex-1" />
         <div className="flex justify-between items-center pt-2 mt-2 w-full gap-2">

--- a/packages/nextjs/app/builds/[buildId]/page.tsx
+++ b/packages/nextjs/app/builds/[buildId]/page.tsx
@@ -8,6 +8,7 @@ import { LikeBuildButton } from "~~/app/builders/[address]/_components/builds/Li
 import { Address } from "~~/components/scaffold-eth";
 import { getBuildByBuildId } from "~~/services/database/repositories/builds";
 import { fetchGithubBuildReadme } from "~~/services/github";
+import { formatShortDate } from "~~/utils/date";
 
 export default async function BuildPage(props: { params: Promise<{ buildId: string }> }) {
   const params = await props.params;
@@ -22,17 +23,12 @@ export default async function BuildPage(props: { params: Promise<{ buildId: stri
       <div className="flex flex-col bg-base-100 rounded-lg w-full lg:max-w-[950px]">
         <div className="flex flex-col md:flex-row justify-between gap-4 p-6">
           <div className="flex flex-col space-y-3 items-center md:items-start text-center md:text-left">
-            <h1 className="text-2xl font-bold">{build?.name}</h1>
-            {build?.submittedTimestamp && (
-              <p className="text-sm text-neutral m-0">
-                Submitted:{" "}
-                {new Date(build.submittedTimestamp).toLocaleDateString("en-US", {
-                  year: "numeric",
-                  month: "short",
-                  day: "numeric",
-                })}
-              </p>
-            )}
+            <div>
+              <h1 className="m-0 text-2xl font-bold">{build?.name}</h1>
+              {build?.submittedTimestamp && (
+                <p className="mt-1 mb-0 text-sm text-neutral">{formatShortDate(build.submittedTimestamp)}</p>
+              )}
+            </div>
             <div className="flex space-x-3">
               {build?.githubUrl && (
                 <Link href={build?.githubUrl} target="_blank" className="btn btn-sm btn-outline">

--- a/packages/nextjs/app/builds/[buildId]/page.tsx
+++ b/packages/nextjs/app/builds/[buildId]/page.tsx
@@ -23,6 +23,16 @@ export default async function BuildPage(props: { params: Promise<{ buildId: stri
         <div className="flex flex-col md:flex-row justify-between gap-4 p-6">
           <div className="flex flex-col space-y-3 items-center md:items-start text-center md:text-left">
             <h1 className="text-2xl font-bold">{build?.name}</h1>
+            {build?.submittedTimestamp && (
+              <p className="text-sm text-neutral m-0">
+                Submitted:{" "}
+                {new Date(build.submittedTimestamp).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                })}
+              </p>
+            )}
             <div className="flex space-x-3">
               {build?.githubUrl && (
                 <Link href={build?.githubUrl} target="_blank" className="btn btn-sm btn-outline">

--- a/packages/nextjs/app/builds/_components/AllBuilds.tsx
+++ b/packages/nextjs/app/builds/_components/AllBuilds.tsx
@@ -17,7 +17,6 @@ type SortOption = `${BuildSort}-${BuildSortDirection}`;
 
 const SORT_OPTIONS: { value: SortOption; label: string }[] = [
   { value: "likes-desc", label: "Most Liked" },
-  { value: "likes-asc", label: "Least Liked" },
   { value: "date-desc", label: "Newest" },
   { value: "date-asc", label: "Oldest" },
   { value: "name-asc", label: "Name (A-Z)" },
@@ -29,8 +28,8 @@ const DEFAULT_SORT: SortOption = "likes-desc";
 export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCategory; type?: BuildType } }) {
   const router = useRouter();
   const pathname = usePathname();
-  const [categoryFilter, setCategoryFilter] = useState(searchParams.category || "");
-  const [typeFilter, setTypeFilter] = useState(searchParams.type || "");
+  const [categoryFilter, setCategoryFilter] = useState<BuildCategory | "">(searchParams.category || "");
+  const [typeFilter, setTypeFilter] = useState<BuildType | "">(searchParams.type || "");
   const [nameFilter, setNameFilter] = useState("");
   const [sortOption, setSortOption] = useState<SortOption>(DEFAULT_SORT);
 
@@ -38,13 +37,14 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
 
   const [sort, direction] = sortOption.split("-") as [BuildSort, BuildSortDirection];
 
-  const { builds, isLoading, isFetching, isFetched, refetch, totalBuilds } = useAllBuildsInfiniteQuery({
-    categoryFilter: categoryFilter as BuildCategory,
-    typeFilter: typeFilter as BuildType,
-    nameFilter: debouncedFilter,
-    sort,
-    direction,
-  });
+  const { builds, isLoading, isFetching, isFetched, refetch, totalBuilds, globalTotalBuilds } =
+    useAllBuildsInfiniteQuery({
+      categoryFilter,
+      typeFilter,
+      nameFilter: debouncedFilter,
+      sort,
+      direction,
+    });
 
   const handleCategoryChange = (category: BuildCategory) => {
     if (!category) {
@@ -79,7 +79,9 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
   return (
     <div className="py-12 px-6 max-w-7xl mx-auto w-full">
       <div className="flex items-center gap-3">
-        <h1 className="m-0 text-2xl font-bold lg:text-4xl">All Builds</h1>
+        <h1 className="m-0 text-2xl font-bold lg:text-4xl">
+          Builds {globalTotalBuilds ? <span className="font-normal">({globalTotalBuilds} total)</span> : null}
+        </h1>
       </div>
       <div className="mt-8">
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-5 lg:gap-6">
@@ -157,7 +159,7 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
           </div>
 
           <div>
-            <p className="mt-0 mb-1 text-sm lg:mb-2">Total Builds</p>
+            <p className="mt-0 mb-1 text-sm lg:mb-2">Filtered Builds</p>
             {isLoading ? (
               <div className="skeleton rounded-md w-24 h-7"></div>
             ) : (

--- a/packages/nextjs/app/builds/_components/AllBuilds.tsx
+++ b/packages/nextjs/app/builds/_components/AllBuilds.tsx
@@ -16,14 +16,14 @@ import { BuildSort, BuildSortDirection } from "~~/services/database/repositories
 type SortOption = `${BuildSort}-${BuildSortDirection}`;
 
 const SORT_OPTIONS: { value: SortOption; label: string }[] = [
-  { value: "likes-desc", label: "Most Liked" },
   { value: "date-desc", label: "Newest" },
   { value: "date-asc", label: "Oldest" },
+  { value: "likes-desc", label: "Most Liked" },
   { value: "name-asc", label: "Name (A-Z)" },
   { value: "name-desc", label: "Name (Z-A)" },
 ];
 
-const DEFAULT_SORT: SortOption = "likes-desc";
+const DEFAULT_SORT: SortOption = "date-desc";
 
 export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCategory; type?: BuildType } }) {
   const router = useRouter();
@@ -211,9 +211,16 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
                     )}
                   </div>
                   <div className="flex flex-col flex-1 px-6 py-4">
-                    <div className="flex items-start gap-3 mb-2">
+                    <div className="flex items-start gap-3 mb-1">
                       <h2 className="text-xl font-bold leading-tight line-clamp-2 flex-1">{build.name}</h2>
                     </div>
+                    <p className="text-xs text-neutral mb-2">
+                      {new Date(build.submittedTimestamp).toLocaleDateString("en-US", {
+                        year: "numeric",
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </p>
                     <p className="text-sm my-1 line-clamp-4">{build.desc}</p>
                     <div className="flex-1" />
                     {build.builders.length > 0 && (

--- a/packages/nextjs/app/builds/_components/AllBuilds.tsx
+++ b/packages/nextjs/app/builds/_components/AllBuilds.tsx
@@ -12,6 +12,7 @@ import { Address } from "~~/components/scaffold-eth";
 import { useAllBuildsInfiniteQuery } from "~~/hooks/useAllBuildsInfiniteQuery";
 import { BuildCategory, BuildType } from "~~/services/database/config/types";
 import { BuildSort, BuildSortDirection } from "~~/services/database/repositories/builds";
+import { formatShortDate } from "~~/utils/date";
 
 type SortOption = `${BuildSort}-${BuildSortDirection}`;
 
@@ -211,17 +212,10 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
                     )}
                   </div>
                   <div className="flex flex-col flex-1 px-6 py-4">
-                    <div className="flex items-start gap-3 mb-1">
-                      <h2 className="text-xl font-bold leading-tight line-clamp-2 flex-1">{build.name}</h2>
+                    <div className="flex items-start gap-3">
+                      <h2 className="m-0 text-xl font-bold leading-tight line-clamp-2 flex-1">{build.name}</h2>
                     </div>
-                    <p className="text-xs text-neutral mb-2">
-                      Submitted:{" "}
-                      {new Date(build.submittedTimestamp).toLocaleDateString("en-US", {
-                        year: "numeric",
-                        month: "short",
-                        day: "numeric",
-                      })}
-                    </p>
+                    <p className="text-xs text-neutral mt-1 mb-2">{formatShortDate(build.submittedTimestamp)}</p>
                     <p className="text-sm my-1 line-clamp-4">{build.desc}</p>
                     <div className="flex-1" />
                     {build.builders.length > 0 && (

--- a/packages/nextjs/app/builds/_components/AllBuilds.tsx
+++ b/packages/nextjs/app/builds/_components/AllBuilds.tsx
@@ -6,9 +6,25 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { LoadingSkeleton } from "./LoadingSkeleton";
 import { useDebounceValue } from "usehooks-ts";
+import { Address as AddressType } from "viem";
 import { LikeBuildButton } from "~~/app/builders/[address]/_components/builds/LikeBuildButton";
+import { Address } from "~~/components/scaffold-eth";
 import { useAllBuildsInfiniteQuery } from "~~/hooks/useAllBuildsInfiniteQuery";
 import { BuildCategory, BuildType } from "~~/services/database/config/types";
+import { BuildSort, BuildSortDirection } from "~~/services/database/repositories/builds";
+
+type SortOption = `${BuildSort}-${BuildSortDirection}`;
+
+const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: "likes-desc", label: "Most Liked" },
+  { value: "likes-asc", label: "Least Liked" },
+  { value: "date-desc", label: "Newest" },
+  { value: "date-asc", label: "Oldest" },
+  { value: "name-asc", label: "Name (A-Z)" },
+  { value: "name-desc", label: "Name (Z-A)" },
+];
+
+const DEFAULT_SORT: SortOption = "likes-desc";
 
 export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCategory; type?: BuildType } }) {
   const router = useRouter();
@@ -16,13 +32,18 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
   const [categoryFilter, setCategoryFilter] = useState(searchParams.category || "");
   const [typeFilter, setTypeFilter] = useState(searchParams.type || "");
   const [nameFilter, setNameFilter] = useState("");
+  const [sortOption, setSortOption] = useState<SortOption>(DEFAULT_SORT);
 
   const [debouncedFilter] = useDebounceValue(nameFilter.length >= 3 ? nameFilter : "", 500);
+
+  const [sort, direction] = sortOption.split("-") as [BuildSort, BuildSortDirection];
 
   const { builds, isLoading, isFetching, isFetched, refetch, totalBuilds } = useAllBuildsInfiniteQuery({
     categoryFilter: categoryFilter as BuildCategory,
     typeFilter: typeFilter as BuildType,
     nameFilter: debouncedFilter,
+    sort,
+    direction,
   });
 
   const handleCategoryChange = (category: BuildCategory) => {
@@ -61,7 +82,7 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
         <h1 className="m-0 text-2xl font-bold lg:text-4xl">All Builds</h1>
       </div>
       <div className="mt-8">
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-4 lg:gap-6">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-5 lg:gap-6">
           <div>
             <p className="mt-0 mb-1 text-sm lg:mb-2">
               {nameFilter ? "Filtering" : "Filter"} By Name{" "}
@@ -116,6 +137,26 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
           </div>
 
           <div>
+            <p className="mt-0 mb-1 text-sm lg:mb-2">
+              Sort By{" "}
+              {sortOption !== DEFAULT_SORT && (
+                <span className="ml-1 inline-block w-2 h-2 bg-[#facb83] rounded-full"></span>
+              )}
+            </p>
+            <select
+              className="select select-sm select-bordered w-full"
+              value={sortOption}
+              onChange={e => setSortOption(e.target.value as SortOption)}
+            >
+              {SORT_OPTIONS.map(option => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
             <p className="mt-0 mb-1 text-sm lg:mb-2">Total Builds</p>
             {isLoading ? (
               <div className="skeleton rounded-md w-24 h-7"></div>
@@ -126,10 +167,9 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
         </div>
         <hr className="hidden my-6 border-base-300 lg:block" />
         <div className="mt-6">
-          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4 lg:gap-6">
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3 lg:gap-6">
             {isLoading && (
               <>
-                <LoadingSkeleton />
                 <LoadingSkeleton />
                 <LoadingSkeleton />
                 <LoadingSkeleton />
@@ -174,6 +214,19 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
                     </div>
                     <p className="text-sm my-1 line-clamp-4">{build.desc}</p>
                     <div className="flex-1" />
+                    {build.builders.length > 0 && (
+                      <div className="grid grid-cols-2 gap-x-2 gap-y-1 pt-3 mt-3 border-t border-base-100">
+                        {build.builders.map(builder => (
+                          <Address
+                            key={builder.userAddress}
+                            address={builder.userAddress as AddressType}
+                            cachedEns={builder.user.ens}
+                            cachedEnsAvatar={builder.user.ensAvatar}
+                            size="xs"
+                          />
+                        ))}
+                      </div>
+                    )}
                     <div className="flex justify-between items-center pt-2 mt-2 w-full gap-2">
                       <Link className="btn btn-sm btn-outline grow" href={`/builds/${build.id}`}>
                         View
@@ -196,11 +249,10 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
                 <LoadingSkeleton />
                 <LoadingSkeleton />
                 <LoadingSkeleton />
-                <LoadingSkeleton />
               </>
             )}
             {isFetched && builds.length === 0 && (
-              <div role="alert" className="alert alert-info md:col-span-2 lg:col-span-4">
+              <div role="alert" className="alert alert-info md:col-span-2 lg:col-span-3">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"

--- a/packages/nextjs/app/builds/_components/AllBuilds.tsx
+++ b/packages/nextjs/app/builds/_components/AllBuilds.tsx
@@ -215,6 +215,7 @@ export function AllBuilds({ searchParams }: { searchParams: { category?: BuildCa
                       <h2 className="text-xl font-bold leading-tight line-clamp-2 flex-1">{build.name}</h2>
                     </div>
                     <p className="text-xs text-neutral mb-2">
+                      Submitted:{" "}
                       {new Date(build.submittedTimestamp).toLocaleDateString("en-US", {
                         year: "numeric",
                         month: "short",

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -38,6 +38,11 @@ export const HeaderMenuLinks = ({ hideItemsByLabel, user }: { hideItemsByLabel?:
         availableForRoles: [UserRole.USER, UserRole.BUILDER, UserRole.ADMIN],
       },
       {
+        label: "Builds",
+        href: "/builds",
+        availableForRoles: [UserRole.USER, UserRole.BUILDER, UserRole.ADMIN],
+      },
+      {
         label: "Build Prompts",
         href: "/build-prompts",
         availableForRoles: [UserRole.USER, UserRole.BUILDER, UserRole.ADMIN],

--- a/packages/nextjs/components/scaffold-eth/BlockieAvatar.tsx
+++ b/packages/nextjs/components/scaffold-eth/BlockieAvatar.tsx
@@ -1,14 +1,30 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { PunkBlockie } from "../PunkBlockie";
 import { AvatarComponent } from "@rainbow-me/rainbowkit";
 
 export const BlockieAvatar: AvatarComponent = ({ address, ensImage, size }) => {
-  if (!ensImage) {
+  const [hasErrored, setHasErrored] = useState(false);
+
+  useEffect(() => {
+    setHasErrored(false);
+  }, [ensImage]);
+
+  if (!ensImage || hasErrored) {
     return <PunkBlockie address={address} width={size} className="rounded-full" />;
   }
 
   // Don't want to use nextJS Image here (and adding remote patterns for the URL)
-  // eslint-disable-next-line @next/next/no-img-element
-  return <img className="rounded-full" src={ensImage} width={size} height={size} alt={`${address} avatar`} />;
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      className="rounded-full"
+      src={ensImage}
+      width={size}
+      height={size}
+      alt={`${address} avatar`}
+      onError={() => setHasErrored(true)}
+    />
+  );
 };

--- a/packages/nextjs/hooks/useAllBuildsInfiniteQuery.tsx
+++ b/packages/nextjs/hooks/useAllBuildsInfiniteQuery.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from "react";
 import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import { fetchBuilds } from "~~/services/api/builds";
 import { BuildCategory, BuildType } from "~~/services/database/config/types";
+import { BuildSort, BuildSortDirection } from "~~/services/database/repositories/builds";
 
 const FETCH_SIZE = 48;
 
@@ -11,19 +12,25 @@ export function useAllBuildsInfiniteQuery({
   categoryFilter,
   typeFilter,
   nameFilter,
+  sort,
+  direction,
 }: {
   categoryFilter: BuildCategory;
   typeFilter: BuildType;
   nameFilter: string;
+  sort: BuildSort;
+  direction: BuildSortDirection;
 }) {
   const { data, isLoading, isFetching, isFetched, refetch, fetchNextPage, hasNextPage } = useInfiniteQuery({
-    queryKey: ["all-builds", nameFilter, categoryFilter, typeFilter],
+    queryKey: ["all-builds", nameFilter, categoryFilter, typeFilter, sort, direction],
     queryFn: async ({ pageParam = 0 }) => {
       const start = (pageParam as number) * FETCH_SIZE;
       const response = await fetchBuilds({
         name: nameFilter,
         category: categoryFilter as BuildCategory,
         type: typeFilter as BuildType,
+        sort,
+        direction,
         start,
         size: FETCH_SIZE,
       });

--- a/packages/nextjs/hooks/useAllBuildsInfiniteQuery.tsx
+++ b/packages/nextjs/hooks/useAllBuildsInfiniteQuery.tsx
@@ -15,8 +15,8 @@ export function useAllBuildsInfiniteQuery({
   sort,
   direction,
 }: {
-  categoryFilter: BuildCategory;
-  typeFilter: BuildType;
+  categoryFilter: BuildCategory | "";
+  typeFilter: BuildType | "";
   nameFilter: string;
   sort: BuildSort;
   direction: BuildSortDirection;
@@ -27,8 +27,8 @@ export function useAllBuildsInfiniteQuery({
       const start = (pageParam as number) * FETCH_SIZE;
       const response = await fetchBuilds({
         name: nameFilter,
-        category: categoryFilter as BuildCategory,
-        type: typeFilter as BuildType,
+        category: categoryFilter,
+        type: typeFilter,
         sort,
         direction,
         start,
@@ -49,6 +49,7 @@ export function useAllBuildsInfiniteQuery({
 
   const builds = useMemo(() => data?.pages?.flatMap(page => page.data) ?? [], [data]);
   const totalBuilds = data?.pages?.[0]?.meta?.totalRowCount ?? 0;
+  const globalTotalBuilds = data?.pages?.[0]?.meta?.globalTotalCount ?? 0;
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -84,5 +85,6 @@ export function useAllBuildsInfiniteQuery({
     isFetched,
     refetch,
     totalBuilds,
+    globalTotalBuilds,
   };
 }

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -8,7 +8,7 @@ export type ScaffoldConfig = {
   onlyLocalBurnerWallet: boolean;
 };
 
-export const DEFAULT_ALCHEMY_API_KEY = "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
+export const DEFAULT_ALCHEMY_API_KEY = "IZYEU2cWBgnFmgiTAgpWD";
 export const BG_MAINNET_RPC_URL = "https://mainnet.rpc.buidlguidl.com";
 
 const scaffoldConfig = {

--- a/packages/nextjs/services/api/builds/index.ts
+++ b/packages/nextjs/services/api/builds/index.ts
@@ -1,16 +1,20 @@
 import { BuildCategory, BuildType } from "~~/services/database/config/types";
-import { Build } from "~~/services/database/repositories/builds";
+import { Build, BuildSort, BuildSortDirection } from "~~/services/database/repositories/builds";
 
 export const fetchBuilds = async ({
   category,
   type,
   name,
+  sort,
+  direction,
   start,
   size,
 }: {
   category?: BuildCategory;
   type?: BuildType;
   name?: string;
+  sort?: BuildSort;
+  direction?: BuildSortDirection;
   start?: number;
   size?: number;
 }) => {
@@ -18,6 +22,8 @@ export const fetchBuilds = async ({
   if (name) params.append("name", name);
   if (category) params.append("category", category);
   if (type) params.append("type", type);
+  if (sort) params.append("sort", sort);
+  if (direction) params.append("direction", direction);
   if (start) params.append("start", start.toString());
   if (size) params.append("size", size.toString());
   const response = await fetch(`/api/builds?${params}`);
@@ -27,7 +33,16 @@ export const fetchBuilds = async ({
   }
 
   const buildsData = (await response.json()) as {
-    data: Array<Build & { likes: Array<{ userAddress: string }> }>;
+    data: Array<
+      Build & {
+        likes: Array<{ userAddress: string }>;
+        builders: Array<{
+          userAddress: string;
+          isOwner: boolean;
+          user: { userAddress: string; ens: string | null; ensAvatar: string | null };
+        }>;
+      }
+    >;
     meta: {
       totalRowCount: string;
     };

--- a/packages/nextjs/services/api/builds/index.ts
+++ b/packages/nextjs/services/api/builds/index.ts
@@ -10,22 +10,22 @@ export const fetchBuilds = async ({
   start,
   size,
 }: {
-  category?: BuildCategory;
-  type?: BuildType;
-  name?: string;
-  sort?: BuildSort;
-  direction?: BuildSortDirection;
-  start?: number;
-  size?: number;
+  category: BuildCategory | "";
+  type: BuildType | "";
+  name: string;
+  sort: BuildSort;
+  direction: BuildSortDirection;
+  start: number;
+  size: number;
 }) => {
   const params = new URLSearchParams();
   if (name) params.append("name", name);
   if (category) params.append("category", category);
   if (type) params.append("type", type);
-  if (sort) params.append("sort", sort);
-  if (direction) params.append("direction", direction);
-  if (start) params.append("start", start.toString());
-  if (size) params.append("size", size.toString());
+  params.append("sort", sort);
+  params.append("direction", direction);
+  params.append("start", start.toString());
+  params.append("size", size.toString());
   const response = await fetch(`/api/builds?${params}`);
 
   if (!response.ok) {
@@ -45,6 +45,7 @@ export const fetchBuilds = async ({
     >;
     meta: {
       totalRowCount: string;
+      globalTotalCount: string;
     };
   };
 

--- a/packages/nextjs/services/database/repositories/builds.ts
+++ b/packages/nextjs/services/database/repositories/builds.ts
@@ -1,8 +1,11 @@
 import { BuildCategory, BuildType } from "../config/types";
 import { filterValidUserAddresses } from "./users";
-import { InferInsertModel, InferSelectModel, and, eq, ilike, inArray, sql } from "drizzle-orm";
+import { InferInsertModel, InferSelectModel, and, asc, desc, eq, ilike, inArray, sql } from "drizzle-orm";
 import { db } from "~~/services/database/config/postgresClient";
 import { buildBuilders, buildLikes, builds, lower } from "~~/services/database/config/schema";
+
+export type BuildSort = "likes" | "name" | "date";
+export type BuildSortDirection = "asc" | "desc";
 
 export type Build = InferSelectModel<typeof builds>;
 export type BuildLike = InferSelectModel<typeof buildLikes>;
@@ -212,30 +215,58 @@ export const getAllBuilds = async ({
   category,
   type,
   nameSearch,
+  sort = "likes",
+  direction = "desc",
   start,
   size,
 }: {
   category?: BuildCategory;
   type?: BuildType;
   nameSearch?: string;
+  sort?: BuildSort;
+  direction?: BuildSortDirection;
   start?: number;
   size?: number;
 }) => {
+  const whereClause = and(
+    category ? eq(builds.buildCategory, category) : undefined,
+    type ? eq(builds.buildType, type) : undefined,
+    nameSearch ? ilike(builds.name, `%${nameSearch}%`) : undefined,
+  );
+
+  const orderFn = direction === "asc" ? asc : desc;
+  const orderBy =
+    sort === "name"
+      ? [orderFn(builds.name)]
+      : sort === "date"
+        ? [orderFn(builds.submittedTimestamp)]
+        : [orderFn(sql`(SELECT COUNT(*) FROM build_likes WHERE build_id = ${builds.id})`)];
+
   const query = db.query.builds.findMany({
-    where: and(
-      category ? eq(builds.buildCategory, category) : undefined,
-      type ? eq(builds.buildType, type) : undefined,
-      nameSearch ? ilike(builds.name, `%${nameSearch}%`) : undefined,
-    ),
+    where: whereClause,
     with: {
       likes: true,
+      builders: {
+        with: {
+          user: {
+            columns: {
+              userAddress: true,
+              ens: true,
+              ensAvatar: true,
+            },
+          },
+        },
+      },
     },
-    orderBy: (builds, { desc, sql }) => [desc(sql`(SELECT COUNT(*) FROM build_likes WHERE build_id = ${builds.id})`)],
+    orderBy,
     limit: size || 48,
     offset: start,
   });
 
-  const countQuery = db.select({ count: sql<number>`count(*)` }).from(builds);
+  const countQuery = db
+    .select({ count: sql<number>`count(*)` })
+    .from(builds)
+    .where(whereClause);
 
   const [buildsData, countResult] = await Promise.all([query, countQuery]);
 

--- a/packages/nextjs/services/database/repositories/builds.ts
+++ b/packages/nextjs/services/database/repositories/builds.ts
@@ -235,12 +235,11 @@ export const getAllBuilds = async ({
   );
 
   const orderFn = direction === "asc" ? asc : desc;
-  const orderBy =
-    sort === "name"
-      ? [orderFn(builds.name)]
-      : sort === "date"
-        ? [orderFn(builds.submittedTimestamp)]
-        : [orderFn(sql`(SELECT COUNT(*) FROM build_likes WHERE build_id = ${builds.id})`)];
+  const sortColumns: Record<BuildSort, ReturnType<typeof orderFn>> = {
+    name: orderFn(builds.name),
+    date: orderFn(builds.submittedTimestamp),
+    likes: orderFn(sql`(SELECT COUNT(*) FROM build_likes WHERE build_id = ${builds.id})`),
+  };
 
   const query = db.query.builds.findMany({
     where: whereClause,
@@ -258,17 +257,29 @@ export const getAllBuilds = async ({
         },
       },
     },
-    orderBy,
+    orderBy: [sortColumns[sort]],
     limit: size || 48,
     offset: start,
   });
 
-  const countQuery = db
+  const filteredCountQuery = db
     .select({ count: sql<number>`count(*)` })
     .from(builds)
     .where(whereClause);
 
-  const [buildsData, countResult] = await Promise.all([query, countQuery]);
+  const totalCountQuery = db.select({ count: sql<number>`count(*)` }).from(builds);
 
-  return { data: buildsData, meta: { totalRowCount: countResult[0]?.count || 0 } };
+  const [buildsData, filteredCountResult, totalCountResult] = await Promise.all([
+    query,
+    filteredCountQuery,
+    totalCountQuery,
+  ]);
+
+  return {
+    data: buildsData,
+    meta: {
+      totalRowCount: filteredCountResult[0]?.count || 0,
+      globalTotalCount: totalCountResult[0]?.count || 0,
+    },
+  };
 };

--- a/packages/nextjs/services/database/repositories/builds.ts
+++ b/packages/nextjs/services/database/repositories/builds.ts
@@ -117,7 +117,7 @@ export const getBuildsByUserAddress = async (userAddress: string) => {
 
   // 2. Fetch all builds, builders, and likes for these IDs in parallel
   const [buildsRows, buildersRows, likesRows] = await Promise.all([
-    db.select().from(builds).where(inArray(builds.id, buildIds)),
+    db.select().from(builds).where(inArray(builds.id, buildIds)).orderBy(desc(builds.submittedTimestamp)),
     db
       .select({
         buildId: buildBuilders.buildId,

--- a/packages/nextjs/utils/date.ts
+++ b/packages/nextjs/utils/date.ts
@@ -48,6 +48,14 @@ export const getRelativeTime = (timestamp: string | number | Date) => {
   return getFutureRelativeTime(timestamp);
 };
 
+// Returns a short date like "Nov 22, 2022"
+export const formatShortDate = (timestamp: string | number | Date) =>
+  new Date(timestamp).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
 export const formatDate = (timestamp: string | number | Date) => {
   const date = new Date(timestamp);
   const formatter = new Intl.DateTimeFormat(undefined, {


### PR DESCRIPTION
https://github.com/user-attachments/assets/8ea7ee52-0321-40f0-b37b-588926e72c96

## Changes

  - **Sorting**: new "Sort By" dropdown — Most/Least Liked (default Most), Newest/Oldest, Name A-Z/Z-A. Threaded through the API (`sort`, `direction` params), repository, hook, and query key.
  - **Filtered total count**: `totalBuilds` now reflects the active filters (the count query reuses the same `where` clause as the data query) instead of always showing the global total.
  - **Builder addresses on cards**: each card shows its builders in a 2-per-row grid above the View/Like row, using the existing `Address` component (ens + avatar). `getAllBuilds` now joins `builders` with their user ens/avatar.
  - **Layout**: cards switched from 4-per-row to 3-per-row on `lg` (mentioned in #314), and the filters bar expanded to 5 columns to fit the new Sort By control.
  - **Header link**: added `Builds → /builds` to the logged-in nav, between Portfolio and Build Prompts. Do we want to make it public? Or maybe change the order of the buttons?

  ### Not included
  - Clearing likes from pre-2024 builds — data migration, separate change. Do we need it?

  ## Test plan
  - [ ] Page loads, default sort is Most Liked.
  - [ ] Switching sort options re-orders results.
  - [ ] Combining Sort with Category/Type/Name filters works; `Total Builds` updates to match.
  - [ ] Each card shows up to 2 builders per row with correct ens/avatar.
  - [ ] Logged-in users see `Builds` in the header between Portfolio and Build Prompts; logged-out users don't.
  - [ ] Infinite scroll still loads more pages.