### PR TITLE
Remove md/mdx ternary after moving to mdx

### DIFF
--- a/packages/nextjs/app/challenge/[challengeId]/page.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/page.tsx
@@ -8,7 +8,7 @@ import { ConnectAndRegisterBanner } from "./_components/ConnectAndRegisterBanner
 import { Details as MdxDetails, Summary as MdxSummary } from "./_components/MdxDetails";
 import { Tab as MdxTab, Tabs as MdxTabs } from "./_components/MdxTabs";
 import { SubmitChallengeButton } from "./_components/SubmitChallengeButton";
-import { MDXRemote } from "next-mdx-remote/rsc";
+import { MDXRemote, type MDXRemoteProps } from "next-mdx-remote/rsc";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
@@ -18,15 +18,24 @@ import {
   getChallengeById,
   getCountOfCompletedChallenge,
 } from "~~/services/database/repositories/challenges";
-import {
-  fetchGithubChallengeReadme,
-  hasMdxComponents,
-  parseGithubUrl,
-  prepareMdxReadme,
-  splitChallengeReadme,
-} from "~~/services/github";
+import { fetchGithubChallengeReadme, parseGithubUrl, prepareMdxReadme, splitChallengeReadme } from "~~/services/github";
 import { CHALLENGE_METADATA, extractHeadings, generateHeadingId } from "~~/utils/challenges";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
+
+const mdxRemoteOptions: MDXRemoteProps["options"] = {
+  mdxOptions: {
+    rehypePlugins: [
+      [
+        rehypeRaw,
+        {
+          passThrough: ["mdxJsxFlowElement", "mdxJsxTextElement", "mdxjsEsm", "mdxFlowExpression", "mdxTextExpression"],
+        },
+      ],
+    ],
+    remarkPlugins: [remarkGfm],
+    format: "mdx",
+  },
+};
 
 export async function generateStaticParams() {
   const challenges = await getAllChallenges();
@@ -65,8 +74,7 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
   }
 
   const rawReadme = await fetchGithubChallengeReadme(challenge.github);
-  const isMdx = hasMdxComponents(rawReadme);
-  const challengeReadme = isMdx ? prepareMdxReadme(rawReadme) : rawReadme;
+  const challengeReadme = prepareMdxReadme(rawReadme);
   const { headerImageMdx, restMdx } = splitChallengeReadme(challengeReadme);
   const { owner, repo, branch } = parseGithubUrl(challenge.github);
 
@@ -92,31 +100,8 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
             <div className="prose dark:prose-invert max-w-fit break-words lg:max-w-[850px]">
               <MDXRemote
                 source={headerImageMdx}
-                components={
-                  isMdx ? { Tabs: MdxTabs, Tab: MdxTab, Details: MdxDetails, Summary: MdxSummary } : undefined
-                }
-                options={{
-                  mdxOptions: {
-                    rehypePlugins: isMdx
-                      ? [
-                          [
-                            rehypeRaw,
-                            {
-                              passThrough: [
-                                "mdxJsxFlowElement",
-                                "mdxJsxTextElement",
-                                "mdxjsEsm",
-                                "mdxFlowExpression",
-                                "mdxTextExpression",
-                              ],
-                            },
-                          ],
-                        ]
-                      : [rehypeRaw],
-                    remarkPlugins: [remarkGfm],
-                    format: isMdx ? "mdx" : "md",
-                  },
-                }}
+                components={{ Tabs: MdxTabs, Tab: MdxTab, Details: MdxDetails, Summary: MdxSummary }}
+                options={mdxRemoteOptions}
               />
             </div>
             <ChallengeHeader
@@ -134,30 +119,12 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
                   a: (props: ComponentPropsWithoutRef<"a">) =>
                     createElement("a", { ...props, target: "_blank", rel: "noopener" }),
                   h2: createH2WithId,
-                  ...(isMdx ? { Tabs: MdxTabs, Tab: MdxTab, Details: MdxDetails, Summary: MdxSummary } : {}),
+                  Tabs: MdxTabs,
+                  Tab: MdxTab,
+                  Details: MdxDetails,
+                  Summary: MdxSummary,
                 }}
-                options={{
-                  mdxOptions: {
-                    rehypePlugins: isMdx
-                      ? [
-                          [
-                            rehypeRaw,
-                            {
-                              passThrough: [
-                                "mdxJsxFlowElement",
-                                "mdxJsxTextElement",
-                                "mdxjsEsm",
-                                "mdxFlowExpression",
-                                "mdxTextExpression",
-                              ],
-                            },
-                          ],
-                        ]
-                      : [rehypeRaw],
-                    remarkPlugins: [remarkGfm],
-                    format: isMdx ? "mdx" : "md",
-                  },
-                }}
+                options={mdxRemoteOptions}
               />
             </div>
 

--- a/packages/nextjs/services/database/config/types.ts
+++ b/packages/nextjs/services/database/config/types.ts
@@ -22,9 +22,6 @@ export enum ChallengeId {
   STABLECOINS = "stablecoins",
   ZK_VOTING = "zk-voting",
   ORACLES = "oracles",
-  MULTISIG = "multisig",
-  SVG_NFT = "svg-nft",
-  STATE_CHANNELS = "state-channels",
 }
 
 export enum BatchStatus {

--- a/packages/nextjs/services/database/seed.data.example.ts
+++ b/packages/nextjs/services/database/seed.data.example.ts
@@ -10,7 +10,7 @@ import {
   UserRole,
 } from "./config/types";
 
-export const SEED_DATA_VERSION = "1.1.8";
+export const SEED_DATA_VERSION = "1.1.9";
 
 // Using Drizzle's inferred insert types to ensure seed data
 // matches database schema requirements
@@ -159,45 +159,6 @@ export const seedChallenges: (typeof challenges.$inferInsert)[] = [
       "🔒 Build your own decentralized voting system using zero-knowledge proofs. Let's write a contract that allows users to vote on a topic and the results will be computed off-chain using zero-knowledge proofs.",
     sortOrder: 9,
     previewImage: "/assets/challenges/zkVoting.svg",
-  },
-  {
-    id: ChallengeId.MULTISIG,
-    challengeName: "Multisig Wallet",
-    github: "scaffold-eth/se-2-challenges:challenge-multisig",
-    autograding: false,
-    description:
-      '👩‍👩‍👧‍👧 Using a smart contract as a wallet we can secure assets by requiring multiple accounts to "vote" on transactions. The contract will keep track of transactions in an array of structs and owners will confirm or reject each one. Any transaction with enough confirmations can "execute".',
-    sortOrder: 100,
-    previewImage: "/assets/challenges/multiSig.svg",
-    externalLink: {
-      link: "https://t.me/+zKllN8OlGuxmYzFh",
-      claim: "Join the 👛 Multisig Build cohort",
-    },
-  },
-  {
-    id: ChallengeId.SVG_NFT,
-    challengeName: "SVG NFT",
-    github: "scaffold-eth/se-2-challenges:challenge-svg-nft",
-    autograding: false,
-    description:
-      "🎨 Create a dynamic SVG NFT using a smart contract. Your contract will generate on-chain SVG images and allow users to mint their unique NFTs. ✨ Customize your SVG graphics and metadata directly within the smart contract. 🚀 Share the minting URL once your project is live!",
-    sortOrder: 101,
-    previewImage: "/assets/challenges/dynamicSvgNFT.svg",
-    externalLink: {
-      link: "https://t.me/+mUeITJ5u7Ig0ZWJh",
-      claim: "Join the 🎁 SVG NFT 🎫 Building Cohort",
-    },
-  },
-  {
-    id: ChallengeId.STATE_CHANNELS,
-    challengeName: "A State Channel Application",
-    github: "scaffold-eth/se-2-challenges:challenge-5-state-channels",
-    autograding: true,
-    description:
-      "🛣️ The Ethereum blockchain has great decentralization & security properties but these properties come at a price: transaction throughput is low, and transactions can be expensive. This makes many traditional web applications infeasible on a blockchain... or does it?  State channels look to solve these problems by allowing participants to securely transact off-chain while keeping interaction with Ethereum Mainnet at a minimum.",
-    sortOrder: 99,
-    previewImage: "/assets/challenges/state.svg",
-    disabled: true,
   },
 ];
 

--- a/packages/nextjs/services/github.ts
+++ b/packages/nextjs/services/github.ts
@@ -149,14 +149,6 @@ export const fetchGithubBuildReadme = async (githubUrl: string): Promise<string 
 };
 
 /**
- * Check if a README contains MDX components (like <Tabs>) that require
- * MDX format parsing instead of plain markdown.
- */
-export const hasMdxComponents = (markdown: string): boolean => {
-  return /<Tabs[\s>]/m.test(markdown);
-};
-
-/**
  * Prepare a README that contains MDX components for rendering.
  * Only needed for READMEs with MDX components (e.g. <Tabs>/<Tab>).
  * - Self-closes void HTML elements for JSX compatibility

--- a/packages/nextjs/utils/challenges.ts
+++ b/packages/nextjs/utils/challenges.ts
@@ -315,16 +315,6 @@ export const CHALLENGE_METADATA: Record<string, ChallengeStaticMetadata> = {
       },
     ],
   },
-  [ChallengeId.MULTISIG]: {
-    title: "Build a Multisignature Wallet in Solidity",
-    description:
-      "Learn to build a multisignature wallet in Solidity that requires multiple approvals for transactions. Essential security pattern for Ethereum developers.",
-  },
-  [ChallengeId.SVG_NFT]: {
-    title: "Create On-Chain SVG NFTs with Solidity",
-    description:
-      "Learn to generate on-chain SVG graphics and create fully on-chain NFTs using Solidity smart contracts. Advanced NFT development tutorial.",
-  },
 };
 
 export function generateHeadingId(text: string): string {


### PR DESCRIPTION
Note: we still have pages with old formatting: `/multisig`, `/svg-nft` and `/state-channels`. Locally, the first ones are working. Last one configured to redirect to `/`. So I think nothing should break. 

Update: build succeeds, pages are working [multisig](https://speedrunethereum-v2-36gk0za99-buidlguidldao.vercel.app/challenge/multisig), [svg-nft](https://speedrunethereum-v2-36gk0za99-buidlguidldao.vercel.app/challenge/svg-nft)

And maybe it's time to remove those pages? cc @carletex 

Fixes #375 