### PR TITLE
AI chat: conversation logging (session-per-row jsonb)

### DIFF
--- a/packages/nextjs/app/api/chat/route.ts
+++ b/packages/nextjs/app/api/chat/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Register as a builder to use the assistant." }, { status: 403 });
   }
 
-  // conversationId is the client-minted session id; it keys the persisted transcript row (ADR 0004).
+  // conversationId keys the persisted transcript row.
   if (!messages || !challengeId || typeof conversationId !== "string") {
     return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
   }

--- a/packages/nextjs/app/api/chat/route.ts
+++ b/packages/nextjs/app/api/chat/route.ts
@@ -9,9 +9,7 @@ import { buildChatSystemPrompt } from "~~/utils/ai/system-prompt";
 
 export const maxDuration = 60;
 
-// Server-side id for each new assistant message. The SDK's generator (prefixed, collision-resistant)
-// is the canonical persistence choice; the id is streamed to the client so its copy and the stored
-// copy match. Distinct from conversationId (the row PK / opik session id), which stays a uuid.
+// Stable ids for persisted assistant messages (streamed to the client so both copies match).
 const newMessageId = createIdGenerator({ prefix: "msg", size: 16 });
 
 export async function POST(req: NextRequest) {
@@ -71,22 +69,14 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  // Drain the stream server-side (no await) so onFinish still fires — and the row still saves —
-  // if the builder closes the tab mid-answer.
+  // Drain server-side so the transcript still saves if the builder closes the tab mid-answer.
   void result.consumeStream();
 
   return result.toUIMessageStreamResponse({
-    // streamText only ever sees model messages, so without originalMessages the response's onFinish
-    // would hand back just the new assistant turn. Passing the incoming UIMessage[] puts the SDK in
-    // "persistence mode": onFinish.messages becomes originalMessages + the response, i.e. the whole
-    // conversation, and the response message gets a real id (not "").
+    // Persistence mode: onFinish gets the whole conversation (with ids), not just the new turn.
     originalMessages: messages,
-    // The last original message is the user's, so a fresh assistant message is created; without this
-    // it would be stored with an empty id. Give every persisted message a real id.
     generateMessageId: newMessageId,
-    // Persist the whole assembled conversation once the turn completes. This is the *second*
-    // onFinish: streamText's onFinish (above) charges tokens; this one logs the transcript.
-    // The full UIMessage[] is stored whole (ADR 0004).
+    // Log the full transcript once the turn completes (the token charge happens above in streamText).
     onFinish: ({ messages: updatedMessages }) => {
       void upsertChatConversation(conversationId, userAddress, challengeId, updatedMessages);
     },

--- a/packages/nextjs/app/api/chat/route.ts
+++ b/packages/nextjs/app/api/chat/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { convertToModelMessages, streamText } from "ai";
+import { upsertChatConversation } from "~~/services/database/repositories/chatConversations";
 import { getUserByAddress } from "~~/services/database/repositories/users";
 import { fetchGithubChallengeReadme, fetchGithubConceptsYaml } from "~~/services/github";
 import { getChatModel } from "~~/utils/ai/models";
@@ -9,7 +10,7 @@ import { buildChatSystemPrompt } from "~~/utils/ai/system-prompt";
 export const maxDuration = 60;
 
 export async function POST(req: NextRequest) {
-  const { messages, challengeId, github, address } = await req.json();
+  const { messages, challengeId, github, address, conversationId } = await req.json();
 
   // TODO: this is not proof of ownership:
   // a client could send any registered address (impersonation is accepted for now; future EIP-712 or SIWE?).
@@ -24,7 +25,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Register as a builder to use the assistant." }, { status: 403 });
   }
 
-  if (!messages || !challengeId) {
+  // conversationId is the client-minted session id; it keys the persisted transcript row (ADR 0004).
+  if (!messages || !challengeId || typeof conversationId !== "string") {
     return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
   }
 
@@ -64,5 +66,16 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  return result.toUIMessageStreamResponse();
+  // Drain the stream server-side (no await) so onFinish still fires — and the row still saves —
+  // if the builder closes the tab mid-answer.
+  void result.consumeStream();
+
+  return result.toUIMessageStreamResponse({
+    // Persist the whole assembled conversation once the turn completes. This is the *second*
+    // onFinish: streamText's onFinish (above) charges tokens; this one logs the transcript.
+    // toUIMessageStreamResponse hands back the full UIMessage[], which we store whole (ADR 0004).
+    onFinish: ({ messages: updatedMessages }) => {
+      void upsertChatConversation(conversationId, userAddress, challengeId, updatedMessages);
+    },
+  });
 }

--- a/packages/nextjs/app/api/chat/route.ts
+++ b/packages/nextjs/app/api/chat/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { convertToModelMessages, streamText } from "ai";
+import { convertToModelMessages, createIdGenerator, streamText } from "ai";
 import { upsertChatConversation } from "~~/services/database/repositories/chatConversations";
 import { getUserByAddress } from "~~/services/database/repositories/users";
 import { fetchGithubChallengeReadme, fetchGithubConceptsYaml } from "~~/services/github";
@@ -8,6 +8,11 @@ import { MAX_OUTPUT_TOKENS, chargeTokenUsage, isOverDailyBudget } from "~~/utils
 import { buildChatSystemPrompt } from "~~/utils/ai/system-prompt";
 
 export const maxDuration = 60;
+
+// Server-side id for each new assistant message. The SDK's generator (prefixed, collision-resistant)
+// is the canonical persistence choice; the id is streamed to the client so its copy and the stored
+// copy match. Distinct from conversationId (the row PK / opik session id), which stays a uuid.
+const newMessageId = createIdGenerator({ prefix: "msg", size: 16 });
 
 export async function POST(req: NextRequest) {
   const { messages, challengeId, github, address, conversationId } = await req.json();
@@ -78,7 +83,7 @@ export async function POST(req: NextRequest) {
     originalMessages: messages,
     // The last original message is the user's, so a fresh assistant message is created; without this
     // it would be stored with an empty id. Give every persisted message a real id.
-    generateMessageId: () => crypto.randomUUID(),
+    generateMessageId: newMessageId,
     // Persist the whole assembled conversation once the turn completes. This is the *second*
     // onFinish: streamText's onFinish (above) charges tokens; this one logs the transcript.
     // The full UIMessage[] is stored whole (ADR 0004).

--- a/packages/nextjs/app/api/chat/route.ts
+++ b/packages/nextjs/app/api/chat/route.ts
@@ -71,9 +71,17 @@ export async function POST(req: NextRequest) {
   void result.consumeStream();
 
   return result.toUIMessageStreamResponse({
+    // streamText only ever sees model messages, so without originalMessages the response's onFinish
+    // would hand back just the new assistant turn. Passing the incoming UIMessage[] puts the SDK in
+    // "persistence mode": onFinish.messages becomes originalMessages + the response, i.e. the whole
+    // conversation, and the response message gets a real id (not "").
+    originalMessages: messages,
+    // The last original message is the user's, so a fresh assistant message is created; without this
+    // it would be stored with an empty id. Give every persisted message a real id.
+    generateMessageId: () => crypto.randomUUID(),
     // Persist the whole assembled conversation once the turn completes. This is the *second*
     // onFinish: streamText's onFinish (above) charges tokens; this one logs the transcript.
-    // toUIMessageStreamResponse hands back the full UIMessage[], which we store whole (ADR 0004).
+    // The full UIMessage[] is stored whole (ADR 0004).
     onFinish: ({ messages: updatedMessages }) => {
       void upsertChatConversation(conversationId, userAddress, challengeId, updatedMessages);
     },

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
@@ -32,6 +32,13 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
   useEffect(() => {
     connectedAddressRef.current = connectedAddress;
   }, [connectedAddress]);
+
+  // One conversationId per chat session, minted client-side (ADR 0004): a new id = a new logged row.
+  // Held in a ref so the memoized transport reads the current id at send time; reset mints a fresh one.
+  const conversationIdRef = useRef<string>("");
+  if (!conversationIdRef.current) {
+    conversationIdRef.current = crypto.randomUUID();
+  }
   const [isOpen, setIsOpen] = useState(false);
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -47,7 +54,13 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
         api: "/api/chat",
         // Build the body at send time so the wallet address is always current (a memo would capture it stale).
         prepareSendMessagesRequest: ({ messages }) => ({
-          body: { messages, challengeId, github, address: connectedAddressRef.current },
+          body: {
+            messages,
+            challengeId,
+            github,
+            address: connectedAddressRef.current,
+            conversationId: conversationIdRef.current,
+          },
         }),
       }),
     [challengeId, github],
@@ -103,6 +116,8 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
   const handleReset = () => {
     setMessages([]);
     setIsSubmitting(false);
+    // Start a clean session so a mid-challenge clear logs to a new row, not the old one.
+    conversationIdRef.current = crypto.randomUUID();
   };
 
   const handleRetry = async () => {

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
@@ -33,8 +33,8 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
     connectedAddressRef.current = connectedAddress;
   }, [connectedAddress]);
 
-  // One conversationId per chat session, minted client-side (ADR 0004): a new id = a new logged row.
-  // Held in a ref so the memoized transport reads the current id at send time; reset mints a fresh one.
+  // One conversationId per session = one logged row. In a ref so the memoized transport reads the
+  // current id at send time; reset mints a fresh one.
   const conversationIdRef = useRef<string>("");
   if (!conversationIdRef.current) {
     conversationIdRef.current = crypto.randomUUID();

--- a/packages/nextjs/services/database/config/schema.ts
+++ b/packages/nextjs/services/database/config/schema.ts
@@ -8,6 +8,7 @@ import {
   UTMParams,
   UserRole,
 } from "./types";
+import type { UIMessage } from "ai";
 import { SQL, relations, sql } from "drizzle-orm";
 import {
   AnyPgColumn,
@@ -143,6 +144,22 @@ export const chatTokenUsage = pgTable(
   },
   table => [primaryKey({ columns: [table.userAddress, table.day] })],
 );
+
+// One AI chat session per row, the whole conversation held in a single jsonb document.
+// The id is minted client-side at session start (= the opik session_id); a new id = a new row.
+// Stored whole rather than a row-per-message: on ai-sdk v6 a UIMessage is a structured object
+// (parts[] + metadata), and toUIMessageStreamResponse hands back the assembled array, so the
+// array is the SDK's own persistence shape. Aggregation reads these blobs later into its own
+// store keyed by conversationId — this table stays a pure append-only session log. See ADR 0004.
+export const chatConversations = pgTable("chat_conversations", {
+  id: uuid().primaryKey(), // client-minted at session start, not server-defaulted
+  userAddress: varchar({ length: 42 }).notNull(),
+  challengeId: varchar({ length: 255 }).notNull(), // known the moment the chat opens
+  messages: jsonb().$type<UIMessage[]>().notNull(), // the whole conversation, one jsonb document
+  messageCount: integer().default(0).notNull(),
+  createdAt: timestamp().defaultNow().notNull(),
+  updatedAt: timestamp().defaultNow().notNull(),
+});
 
 export const builds = pgTable(
   "builds",

--- a/packages/nextjs/services/database/config/schema.ts
+++ b/packages/nextjs/services/database/config/schema.ts
@@ -145,14 +145,9 @@ export const chatTokenUsage = pgTable(
   table => [primaryKey({ columns: [table.userAddress, table.day] })],
 );
 
-// One AI chat session per row, the whole conversation held in a single jsonb document.
-// The id is minted client-side at session start (= the opik session_id); a new id = a new row.
-// Stored whole rather than a row-per-message: on ai-sdk v6 a UIMessage is a structured object
-// (parts[] + metadata), and toUIMessageStreamResponse hands back the assembled array, so the
-// array is the SDK's own persistence shape. Aggregation reads these blobs later into its own
-// store keyed by conversationId — this table stays a pure append-only session log. See ADR 0004.
+// One AI chat session per row; the whole conversation in a single jsonb document, upserted each turn.
 export const chatConversations = pgTable("chat_conversations", {
-  id: uuid().primaryKey(), // client-minted at session start, not server-defaulted
+  id: uuid().primaryKey(), // client-minted, not server-defaulted
   userAddress: varchar({ length: 42 }).notNull(),
   challengeId: varchar({ length: 255 }).notNull(), // known the moment the chat opens
   messages: jsonb().$type<UIMessage[]>().notNull(), // the whole conversation, one jsonb document

--- a/packages/nextjs/services/database/migrations/0016_classy_toad_men.sql
+++ b/packages/nextjs/services/database/migrations/0016_classy_toad_men.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "chat_conversations" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"user_address" varchar(42) NOT NULL,
+	"challenge_id" varchar(255) NOT NULL,
+	"messages" jsonb NOT NULL,
+	"message_count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);

--- a/packages/nextjs/services/database/migrations/meta/0016_snapshot.json
+++ b/packages/nextjs/services/database/migrations/meta/0016_snapshot.json
@@ -1,0 +1,991 @@
+{
+  "id": "5a2ce51e-8cbe-467f-9391-e97a8cc4cae9",
+  "prevId": "ba39f581-14f0-4a86-91e9-1cf7ea503eb8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status_enum",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_link": {
+          "name": "telegram_link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bg_subdomain": {
+          "name": "bg_subdomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "batch_network",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.build_builders": {
+      "name": "build_builders",
+      "schema": "",
+      "columns": {
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "build_builder_user_idx": {
+          "name": "build_builder_user_idx",
+          "columns": [
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "build_builders_build_id_builds_id_fk": {
+          "name": "build_builders_build_id_builds_id_fk",
+          "tableFrom": "build_builders",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "build_builders_user_address_users_user_address_fk": {
+          "name": "build_builders_user_address_users_user_address_fk",
+          "tableFrom": "build_builders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_address"
+          ],
+          "columnsTo": [
+            "user_address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "build_builders_build_id_user_address_pk": {
+          "name": "build_builders_build_id_user_address_pk",
+          "columns": [
+            "build_id",
+            "user_address"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.build_likes": {
+      "name": "build_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked_at": {
+          "name": "liked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "build_like_unique_idx": {
+          "name": "build_like_unique_idx",
+          "columns": [
+            {
+              "expression": "build_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "build_likes_build_id_builds_id_fk": {
+          "name": "build_likes_build_id_builds_id_fk",
+          "tableFrom": "build_likes",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "build_likes_user_address_users_user_address_fk": {
+          "name": "build_likes_user_address_users_user_address_fk",
+          "tableFrom": "build_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_address"
+          ],
+          "columnsTo": [
+            "user_address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.builds": {
+      "name": "builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desc": {
+          "name": "desc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_type": {
+          "name": "build_type",
+          "type": "build_type_enum",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_category": {
+          "name": "build_category",
+          "type": "build_category_enum",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_url": {
+          "name": "demo_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_timestamp": {
+          "name": "submitted_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "bg_grant": {
+          "name": "bg_grant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "build_type_idx": {
+          "name": "build_type_idx",
+          "columns": [
+            {
+              "expression": "build_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "build_category_idx": {
+          "name": "build_category_idx",
+          "columns": [
+            {
+              "expression": "build_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenge_name": {
+          "name": "challenge_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autograding": {
+          "name": "autograding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "preview_image": {
+          "name": "preview_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_link": {
+          "name": "external_link",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_conversations": {
+      "name": "chat_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_token_usage": {
+      "name": "chat_token_usage",
+      "schema": "",
+      "columns": {
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_token_usage_user_address_day_pk": {
+          "name": "chat_token_usage_user_address_day_pk",
+          "columns": [
+            "user_address",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenges": {
+      "name": "user_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frontend_url": {
+          "name": "frontend_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_url": {
+          "name": "contract_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_comment": {
+          "name": "review_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "review_action": {
+          "name": "review_action",
+          "type": "review_action_enum",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_challenge_lookup_idx": {
+          "name": "user_challenge_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_challenge_review_idx": {
+          "name": "user_challenge_review_idx",
+          "columns": [
+            {
+              "expression": "user_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenges_user_address_users_user_address_fk": {
+          "name": "user_challenges_user_address_users_user_address_fk",
+          "tableFrom": "user_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_address"
+          ],
+          "columnsTo": [
+            "user_address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenges_challenge_id_challenges_id_fk": {
+          "name": "user_challenges_challenge_id_challenges_id_fk",
+          "tableFrom": "user_challenges",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notes": {
+      "name": "user_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notes_user_address_users_user_address_fk": {
+          "name": "user_notes_user_address_users_user_address_fk",
+          "tableFrom": "user_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_address"
+          ],
+          "columnsTo": [
+            "user_address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_notes_author_address_users_user_address_fk": {
+          "name": "user_notes_author_address_users_user_address_fk",
+          "tableFrom": "user_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "user_address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_address": {
+          "name": "user_address",
+          "type": "varchar(42)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role_enum",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USER'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ens": {
+          "name": "ens",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ens_avatar": {
+          "name": "ens_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_telegram": {
+          "name": "social_telegram",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_x": {
+          "name": "social_x",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_github": {
+          "name": "social_github",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_instagram": {
+          "name": "social_instagram",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_discord": {
+          "name": "social_discord",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_email": {
+          "name": "social_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_farcaster": {
+          "name": "social_farcaster",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_status": {
+          "name": "batch_status",
+          "type": "batch_user_status_enum",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_utm_params": {
+          "name": "original_utm_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sidequests_snapshot": {
+          "name": "sidequests_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idUniqueIndex": {
+          "name": "idUniqueIndex",
+          "columns": [
+            {
+              "expression": "lower(\"user_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_batch_id_batches_id_fk": {
+          "name": "users_batch_id_batches_id_fk",
+          "tableFrom": "users",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.batch_network": {
+      "name": "batch_network",
+      "schema": "public",
+      "values": [
+        "arbitrum",
+        "optimism"
+      ]
+    },
+    "public.batch_status_enum": {
+      "name": "batch_status_enum",
+      "schema": "public",
+      "values": [
+        "closed",
+        "open"
+      ]
+    },
+    "public.batch_user_status_enum": {
+      "name": "batch_user_status_enum",
+      "schema": "public",
+      "values": [
+        "graduate",
+        "candidate"
+      ]
+    },
+    "public.build_category_enum": {
+      "name": "build_category_enum",
+      "schema": "public",
+      "values": [
+        "DeFi",
+        "Gaming",
+        "NFTs",
+        "Social",
+        "DAOs & Governance",
+        "Dev Tooling",
+        "Identity & Reputation",
+        "RWA & Supply Chain",
+        "AI Agents",
+        "Prediction Markets"
+      ]
+    },
+    "public.build_type_enum": {
+      "name": "build_type_enum",
+      "schema": "public",
+      "values": [
+        "Dapp",
+        "Infrastructure",
+        "Challenge submission",
+        "Content",
+        "Design",
+        "Other"
+      ]
+    },
+    "public.review_action_enum": {
+      "name": "review_action_enum",
+      "schema": "public",
+      "values": [
+        "REJECTED",
+        "ACCEPTED",
+        "SUBMITTED"
+      ]
+    },
+    "public.user_role_enum": {
+      "name": "user_role_enum",
+      "schema": "public",
+      "values": [
+        "USER",
+        "BUILDER",
+        "ADMIN"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/nextjs/services/database/migrations/meta/_journal.json
+++ b/packages/nextjs/services/database/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1780852296516,
       "tag": "0015_conscious_pixie",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1781075576802,
+      "tag": "0016_classy_toad_men",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/nextjs/services/database/repositories/chatConversations.ts
+++ b/packages/nextjs/services/database/repositories/chatConversations.ts
@@ -1,0 +1,27 @@
+import type { UIMessage } from "ai";
+import { sql } from "drizzle-orm";
+import { db } from "~~/services/database/config/postgresClient";
+import { chatConversations } from "~~/services/database/config/schema";
+
+// Persist a chat session as one row, the whole conversation in a single jsonb document.
+// Called from /api/chat's onFinish after each turn: the id is the client-minted conversationId,
+// so the first turn inserts and every later turn rewrites the same row with the grown transcript.
+// The whole blob is rewritten each time (no per-message diffing) — a few KB per session, so it's free.
+export async function upsertChatConversation(
+  id: string,
+  userAddress: string,
+  challengeId: string,
+  messages: UIMessage[],
+) {
+  await db
+    .insert(chatConversations)
+    .values({ id, userAddress, challengeId, messages, messageCount: messages.length })
+    .onConflictDoUpdate({
+      target: chatConversations.id,
+      set: {
+        messages,
+        messageCount: messages.length,
+        updatedAt: sql`now()`,
+      },
+    });
+}

--- a/packages/nextjs/services/database/repositories/chatConversations.ts
+++ b/packages/nextjs/services/database/repositories/chatConversations.ts
@@ -1,5 +1,5 @@
 import type { UIMessage } from "ai";
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { db } from "~~/services/database/config/postgresClient";
 import { chatConversations } from "~~/services/database/config/schema";
 
@@ -20,5 +20,7 @@ export async function upsertChatConversation(
         messageCount: messages.length,
         updatedAt: sql`now()`,
       },
+      // Only the row's owner can rewrite it, so a guessed/reused id can't clobber someone else's log.
+      setWhere: eq(chatConversations.userAddress, userAddress),
     });
 }

--- a/packages/nextjs/services/database/repositories/chatConversations.ts
+++ b/packages/nextjs/services/database/repositories/chatConversations.ts
@@ -3,10 +3,7 @@ import { sql } from "drizzle-orm";
 import { db } from "~~/services/database/config/postgresClient";
 import { chatConversations } from "~~/services/database/config/schema";
 
-// Persist a chat session as one row, the whole conversation in a single jsonb document.
-// Called from /api/chat's onFinish after each turn: the id is the client-minted conversationId,
-// so the first turn inserts and every later turn rewrites the same row with the grown transcript.
-// The whole blob is rewritten each time (no per-message diffing) — a few KB per session, so it's free.
+// Upsert a chat session: first turn inserts, later turns rewrite the same row with the grown transcript.
 export async function upsertChatConversation(
   id: string,
   userAddress: string,


### PR DESCRIPTION
## Summary

Conversation logging for the per-challenge AI chat assistant. One chat session = one row instead of per-message as row (thanks Carlos for the idea), the whole conversation stored as a single `jsonb` document.  

## Concretely

- New `chat_conversations` table (migration `0016`): one row per session, `messages jsonb` holds the assembled `UIMessage[]`, plus `messageCount`, `createdAt`, `updatedAt`. `id` is the client-minted `conversationId` (PK), not server-defaulted.
- `upsertChatConversation` repo: `INSERT ... ON CONFLICT (id) DO UPDATE` — the first turn inserts, every later turn rewrites the same row with the grown transcript (no per-message diffing).
- `/api/chat` persists the transcript in `toUIMessageStreamResponse`'s `onFinish` (the *full* `UIMessage[]`), separate from the token-charging `onFinish` on `streamText`. `result.consumeStream()` (no `await`) so the row still saves if the builder closes the tab mid-answer.
- `ChatWidget` mints a `conversationId` (`crypto.randomUUID()`) at mount and on reset, and sends it in the request body via a ref (so the memoized transport reads the current id). A new id = a new session row.

Also just created a companion html doc to easily digest the things in code: https://sre-logging-flow.vercel.app

## Why session-per-row (not message-per-row)

On ai-sdk v6 a `UIMessage` is a structured object (`parts[]` + `metadata`), and `toUIMessageStreamResponse` hands back the whole assembled array — so storing the array whole is the SDK's own persistence shape. Per-turn detail lives in Opik when it's enabled, so a per-message table would duplicate it. No digest/insight columns: aggregation reads these blobs later into its own store keyed by `conversationId`, keeping this table a pure append-only log. `chat_token_usage` (the gate) stays its own table — different grain `(userAddress, day)`.

## How to test

```bash
git checkout ai-chat-conversation-logging
cd packages/nextjs
docker compose up -d
yarn drizzle-kit push   # local migrations journal is behind from prior `push` syncs; `push` adds the table. `migrate` runs clean on prod's intact journal.
yarn start
```

Open a challenge, connect a registered wallet, open the assistant, send a couple of messages. A `chat_conversations` row appears keyed by the client `conversationId`; `messageCount` grows each turn (same row). Hit reset, send again — it lands in a new row.

Write path also verified directly against local postgres: first upsert inserts, second upsert with the same id rewrites in place (`createdAt` unchanged, `messageCount` and `updatedAt` advance, exactly one row).

## Deferred

- Opik wiring — zero-code OpenRouter toggle, left off until there's a specific question to watch.
- Digest / insight aggregation into a separate store keyed by `conversationId`.


## Why store the whole message

We log the full `UIMessage[]` per session rather than a slimmed role+text projection. The assistant has no tool calls, so the parts are just text + reasoning, and the reasoning trace is the most useful signal for prompt tuning (catching where the tutor leaks answers). Storage is negligible — a few KB of TOAST-compressed jsonb per session, and the one redundancy (reasoning duplicated in `providerMetadata`) compresses away. Any slim view is a read-time projection in the later digest step, not a lossy write-time transform.
