### PR TITLE
Redesign challenge page layout

### DIFF
--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeHeader.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeHeader.tsx
@@ -1,14 +1,10 @@
 import type { ReactNode } from "react";
-import { MDXRemote } from "next-mdx-remote/rsc";
-import rehypeRaw from "rehype-raw";
-import remarkGfm from "remark-gfm";
-import { CheckCircleIcon, ClockIcon, LinkIcon, UserGroupIcon } from "@heroicons/react/24/outline";
+import { ClockIcon, LinkIcon, UserGroupIcon } from "@heroicons/react/24/outline";
 import SkillLevelIcon from "~~/app/_components/SkillLevelIcon";
 import { SkillLevel } from "~~/utils/challenges";
 
 type Props = {
   title?: string;
-  skills?: string[];
   skillLevel?: SkillLevel;
   timeToComplete?: string;
   helpfulLinks?: { text: string; url?: string }[];
@@ -35,14 +31,7 @@ function Fact({ icon, label, value, children }: FactProps) {
   );
 }
 
-export function ChallengeHeader({
-  skills,
-  skillLevel,
-  timeToComplete,
-  helpfulLinks,
-  completedByCount,
-  children,
-}: Props) {
+export function ChallengeHeader({ skillLevel, timeToComplete, helpfulLinks, completedByCount, children }: Props) {
   return (
     <div className="w-full">
       <div className="relative z-10 -mt-9 mb-6 rounded-2xl bg-base-200 border-2 border-secondary/80 shadow-[0_4px_10px_-2px_rgba(0,0,0,0.12)] grid grid-cols-1 sm:grid-cols-2 md:grid-cols-[0.9fr_1fr_1fr_1.35fr] gap-x-4 gap-y-4 p-6">
@@ -89,39 +78,6 @@ export function ChallengeHeader({
       </div>
 
       <div className="rounded-2xl bg-base-100 border border-primary/10 shadow-sm px-5 py-7 sm:px-8 lg:px-10 lg:py-9">
-        <section>
-          <div className="font-semibold mb-4 text-primary">Skills you&apos;ll gain</div>
-          <div className="flex-1 flex">
-            {skills && skills.length > 0 ? (
-              <ul className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3 text-sm">
-                {skills.slice(0, 4).map(skill => (
-                  <li key={skill} className="flex items-start gap-2">
-                    <CheckCircleIcon className="w-5 h-5 text-primary self-start shrink-0 mt-0.5" />
-                    <div className="flex-1 min-w-0 break-words whitespace-normal leading-5">
-                      <MDXRemote
-                        source={skill}
-                        options={{
-                          mdxOptions: {
-                            rehypePlugins: [rehypeRaw],
-                            remarkPlugins: [remarkGfm],
-                            format: "md",
-                          },
-                        }}
-                        components={{
-                          p: (props: any) => <p className="m-0">{props.children}</p>,
-                        }}
-                      />
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <div className="text-sm opacity-70">This challenge helps you build practical Solidity skills.</div>
-            )}
-          </div>
-        </section>
-
-        <div className="my-8 border-t border-base-content/25" />
         {children}
       </div>
     </div>

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeHeader.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeHeader.tsx
@@ -4,7 +4,6 @@ import SkillLevelIcon from "~~/app/_components/SkillLevelIcon";
 import { SkillLevel } from "~~/utils/challenges";
 
 type Props = {
-  title?: string;
   skillLevel?: SkillLevel;
   timeToComplete?: string;
   helpfulLinks?: { text: string; url?: string }[];

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeHeader.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeHeader.tsx
@@ -121,7 +121,7 @@ export function ChallengeHeader({
           </div>
         </section>
 
-        <div className="my-8 border-t border-base-content/10" />
+        <div className="my-8 border-t border-base-content/25" />
         {children}
       </div>
     </div>

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeHeader.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeHeader.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { ClockIcon, LinkIcon, UserGroupIcon } from "@heroicons/react/24/outline";
+import { ClockIcon, LinkIcon, SparklesIcon, UserGroupIcon } from "@heroicons/react/24/outline";
 import SkillLevelIcon from "~~/app/_components/SkillLevelIcon";
 import { SkillLevel } from "~~/utils/challenges";
 
@@ -8,6 +8,7 @@ type Props = {
   timeToComplete?: string;
   helpfulLinks?: { text: string; url?: string }[];
   completedByCount?: number;
+  isAiReady?: boolean;
   children?: ReactNode;
 };
 
@@ -30,7 +31,14 @@ function Fact({ icon, label, value, children }: FactProps) {
   );
 }
 
-export function ChallengeHeader({ skillLevel, timeToComplete, helpfulLinks, completedByCount, children }: Props) {
+export function ChallengeHeader({
+  skillLevel,
+  timeToComplete,
+  helpfulLinks,
+  completedByCount,
+  isAiReady,
+  children,
+}: Props) {
   return (
     <div className="w-full">
       <div className="relative z-10 -mt-9 mb-6 rounded-2xl bg-base-200 border-2 border-secondary/80 shadow-[0_4px_10px_-2px_rgba(0,0,0,0.12)] grid grid-cols-1 sm:grid-cols-2 md:grid-cols-[0.9fr_1fr_1fr_1.35fr] gap-x-4 gap-y-4 p-6">
@@ -75,6 +83,23 @@ export function ChallengeHeader({ skillLevel, timeToComplete, helpfulLinks, comp
           )}
         </Fact>
       </div>
+
+      {isAiReady && (
+        <div className="mb-6 rounded-2xl border border-primary/10 bg-base-100 p-6 shadow-center flex items-start gap-4">
+          <SparklesIcon className="w-8 h-8 text-primary shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm opacity-80 m-0">
+              This challenge ships with <span className="font-bold">context-aware AI</span> support. Open it in your
+              preferred AI coding tool and ask questions, request hints, or get explanations at any point along the way.
+            </p>
+            <p className="text-sm opacity-80 mt-2 mb-0">
+              If you prefer an <span className="font-bold">AI-guided</span> experience, you can run{" "}
+              <code className="bg-base-300 px-1.5 py-0.5 rounded text-xs font-mono">/start</code> in{" "}
+              <span className="italic">Claude Code</span> or <span className="italic">Cursor</span>.
+            </p>
+          </div>
+        </div>
+      )}
 
       <div className="rounded-2xl bg-base-100 border border-primary/10 shadow-sm px-5 py-7 sm:px-8 lg:px-10 lg:py-9">
         {children}

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeHeader.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeHeader.tsx
@@ -1,7 +1,8 @@
+import type { ReactNode } from "react";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
-import { CheckCircleIcon, ClockIcon, LinkIcon, SparklesIcon, UserGroupIcon } from "@heroicons/react/24/outline";
+import { CheckCircleIcon, ClockIcon, LinkIcon, UserGroupIcon } from "@heroicons/react/24/outline";
 import SkillLevelIcon from "~~/app/_components/SkillLevelIcon";
 import { SkillLevel } from "~~/utils/challenges";
 
@@ -12,8 +13,27 @@ type Props = {
   timeToComplete?: string;
   helpfulLinks?: { text: string; url?: string }[];
   completedByCount?: number;
-  isAiReady?: boolean;
+  children?: ReactNode;
 };
+
+type FactProps = {
+  icon: ReactNode;
+  label: string;
+  value?: ReactNode;
+  children?: ReactNode;
+};
+
+function Fact({ icon, label, value, children }: FactProps) {
+  return (
+    <div className="flex items-start gap-3 min-w-0">
+      <div className="shrink-0 mt-0.5">{icon}</div>
+      <div className="min-w-0">
+        <div className="text-sm text-base-content/70">{label}</div>
+        {children || <div className="font-semibold break-words">{value}</div>}
+      </div>
+    </div>
+  );
+}
 
 export function ChallengeHeader({
   skills,
@@ -21,23 +41,62 @@ export function ChallengeHeader({
   timeToComplete,
   helpfulLinks,
   completedByCount,
-  isAiReady,
+  children,
 }: Props) {
-  if (!skills || skills.length === 0) {
-    return null;
-  }
   return (
-    <div className="w-full max-w-[850px] mx-auto mb-10">
-      <div className="grid grid-cols-1 md:grid-cols-[2fr_1fr] gap-4">
-        {/* Left card: Skills */}
-        <div className="rounded-2xl border border-primary/10 bg-base-100 p-6 shadow-center h-full flex flex-col">
-          <div className="font-semibold mb-3 text-primary">Skills you&apos;ll gain</div>
+    <div className="w-full">
+      <div className="relative z-10 -mt-9 mb-6 rounded-2xl bg-base-200 border-2 border-secondary/80 shadow-[0_4px_10px_-2px_rgba(0,0,0,0.12)] grid grid-cols-1 sm:grid-cols-2 md:grid-cols-[0.9fr_1fr_1fr_1.35fr] gap-x-4 gap-y-4 p-6">
+        <Fact
+          icon={<SkillLevelIcon level={skillLevel} className="w-7 h-7 text-primary" />}
+          label="Skill level"
+          value={skillLevel || "Not specified"}
+        />
+        <Fact
+          icon={<ClockIcon className="w-7 h-7 text-primary" />}
+          label="Time to complete"
+          value={timeToComplete || "-"}
+        />
+        <Fact
+          icon={<UserGroupIcon className="w-7 h-7 text-primary" />}
+          label="Completed by"
+          value={completedByCount ? `${completedByCount} builder${completedByCount > 1 ? "s" : ""}` : "-"}
+        />
+        <Fact icon={<LinkIcon className="w-7 h-7 text-primary" />} label="Helpful links">
+          {helpfulLinks && helpfulLinks.length > 0 ? (
+            <div className="mt-0.5 space-y-1">
+              {helpfulLinks.map((item, idx) =>
+                item.url ? (
+                  <a
+                    key={`${item.text}-${idx}`}
+                    href={item.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="link text-primary font-semibold block text-sm break-words"
+                  >
+                    {item.text}
+                  </a>
+                ) : (
+                  <div key={`${item.text}-${idx}`} className="text-sm font-semibold break-words">
+                    {item.text}
+                  </div>
+                ),
+              )}
+            </div>
+          ) : (
+            <span className="text-sm">None</span>
+          )}
+        </Fact>
+      </div>
+
+      <div className="rounded-2xl bg-base-100 border border-primary/10 shadow-sm px-5 py-7 sm:px-8 lg:px-10 lg:py-9">
+        <section>
+          <div className="font-semibold mb-4 text-primary">Skills you&apos;ll gain</div>
           <div className="flex-1 flex">
             {skills && skills.length > 0 ? (
-              <ul className="space-y-2 text-sm">
+              <ul className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3 text-sm">
                 {skills.slice(0, 4).map(skill => (
                   <li key={skill} className="flex items-start gap-2">
-                    <CheckCircleIcon className="w-5 h-5 text-primary self-start shrink-0" />
+                    <CheckCircleIcon className="w-5 h-5 text-primary self-start shrink-0 mt-0.5" />
                     <div className="flex-1 min-w-0 break-words whitespace-normal leading-5">
                       <MDXRemote
                         source={skill}
@@ -60,81 +119,11 @@ export function ChallengeHeader({
               <div className="text-sm opacity-70">This challenge helps you build practical Solidity skills.</div>
             )}
           </div>
-        </div>
+        </section>
 
-        {/* Right card: Details */}
-        <div className="rounded-2xl border border-primary/10 bg-secondary/20 p-6 shadow-center flex flex-col justify-center">
-          <div className="space-y-4 text-md">
-            <div className="flex items-center gap-3">
-              <SkillLevelIcon level={skillLevel} className="w-8 h-8 text-primary" />
-              <div className="flex-1">
-                <div className="text-sm">Skill level</div>
-                <div className="font-semibold">{skillLevel}</div>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3">
-              <ClockIcon className="w-8 h-8 text-primary" />
-              <div className="flex-1">
-                <div className="text-sm">Time to complete</div>
-                <div className="font-semibold">{timeToComplete || "—"}</div>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3">
-              <UserGroupIcon className="w-8 h-8 text-primary" />
-              <div className="flex-1">
-                <div className="text-sm">Completed by</div>
-                <div className="font-semibold">
-                  {completedByCount ? `${completedByCount} builder${completedByCount > 1 ? "s" : ""}` : "—"}
-                </div>
-              </div>
-            </div>
-
-            <div className="flex items-start gap-3">
-              <LinkIcon className="w-8 h-8 text-primary mt-1" />
-              <div className="flex-1">
-                <div className="text-sm">Helpful links</div>
-                {helpfulLinks && helpfulLinks.length > 0 ? (
-                  <ul className="space-y-1 mt-1 text-sm">
-                    {helpfulLinks.map((item, idx) => (
-                      <li key={`${item.text}-${idx}`} className="break-words whitespace-normal">
-                        <a
-                          href={item.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="link text-primary font-semibold"
-                        >
-                          {item.text}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <span>None</span>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
+        <div className="my-8 border-t border-base-content/10" />
+        {children}
       </div>
-
-      {isAiReady && (
-        <div className="mt-4 rounded-2xl border border-primary/10 bg-base-100 p-6 shadow-center flex items-start gap-4">
-          <SparklesIcon className="w-8 h-8 text-primary shrink-0 mt-0.5" />
-          <div>
-            <p className="text-sm opacity-80 m-0">
-              This challenge ships with <span className="font-bold">context-aware AI</span> support. Open it in your
-              preferred AI coding tool and ask questions, request hints, or get explanations at any point along the way.
-            </p>
-            <p className="text-sm opacity-80 mt-2 mb-0">
-              If you prefer an <span className="font-bold">AI-guided</span> experience, you can run{" "}
-              <code className="bg-base-300 px-1.5 py-0.5 rounded text-xs font-mono">/start</code> in{" "}
-              <span className="italic">Claude Code</span> or <span className="italic">Cursor</span>.
-            </p>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeSidebar.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeSidebar.tsx
@@ -52,7 +52,7 @@ export function ChallengeSidebar({ headings }: ChallengeSidebarProps) {
   };
 
   if (headings.length === 0) {
-    return null;
+    return <div className="hidden lg:block" aria-hidden />;
   }
 
   return (
@@ -66,7 +66,7 @@ export function ChallengeSidebar({ headings }: ChallengeSidebarProps) {
           fixed left-0 top-0 h-full w-72 pt-4 z-40
           bg-base-100 border-r border-base-300 overflow-y-auto
           transition-transform duration-300 ease-in-out
-          lg:sticky lg:top-0 lg:h-screen lg:w-64 lg:shrink-0 lg:translate-x-0 lg:border-r-0 lg:bg-transparent
+          lg:sticky lg:top-3 lg:h-[calc(100vh-1.5rem)] lg:w-auto lg:shrink-0 lg:translate-x-0 lg:border-r-0 lg:bg-transparent lg:pt-3
           ${sidebarIsOpen ? "translate-x-0" : "-translate-x-full"}
         `}
       >
@@ -78,15 +78,15 @@ export function ChallengeSidebar({ headings }: ChallengeSidebarProps) {
           <XMarkIcon className="w-5 h-5" />
         </button>
 
-        <div className="p-4">
+        <div className="p-4 lg:px-0">
           <h3 className="font-semibold text-sm uppercase tracking-wider text-base-content/60 mb-4">On this page</h3>
-          <ul className="space-y-1">
+          <ul className="space-y-1 border-l border-base-content/10">
             {headings.map(heading => (
               <li key={heading.id}>
                 <button
                   onClick={() => handleClick(heading.id)}
                   className={`
-                    block w-full text-left px-3 py-2 text-sm rounded-lg transition-colors border-l-2
+                    block w-full text-left px-3 py-2 text-sm transition-colors border-l-2 -ml-px
                     hover:bg-primary/20 hover:text-primary
                     ${
                       activeId === heading.id

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeSidebar.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeSidebar.tsx
@@ -64,9 +64,9 @@ export function ChallengeSidebar({ headings }: ChallengeSidebarProps) {
       <nav
         className={`
           fixed left-0 top-0 h-full w-72 pt-4 z-40
-          bg-base-100 border-r border-base-300 overflow-y-auto
+          bg-base-100 border-r border-base-300 overflow-y-auto toc-scrollbar
           transition-transform duration-300 ease-in-out
-          lg:sticky lg:top-3 lg:h-[calc(100vh-1.5rem)] lg:w-auto lg:shrink-0 lg:translate-x-0 lg:border-r-0 lg:bg-transparent lg:pt-3
+          lg:sticky lg:top-3 lg:h-auto lg:max-h-[calc(100vh-1.5rem)] lg:w-auto lg:shrink-0 lg:translate-x-0 lg:border-r-0 lg:bg-transparent lg:pt-3
           ${sidebarIsOpen ? "translate-x-0" : "-translate-x-full"}
         `}
       >

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeSkills.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeSkills.tsx
@@ -1,0 +1,40 @@
+import { MDXRemote } from "next-mdx-remote/rsc";
+import rehypeRaw from "rehype-raw";
+import remarkGfm from "remark-gfm";
+import { CheckCircleIcon } from "@heroicons/react/24/outline";
+
+export function ChallengeSkills({ skills }: { skills?: string[] }) {
+  if (!skills || skills.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-6">
+      <div className="mb-3 text-sm font-semibold uppercase tracking-wide text-base-content/70">
+        Skills you&apos;ll gain
+      </div>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2.5 text-sm">
+        {skills.slice(0, 4).map(skill => (
+          <li key={skill} className="flex items-start gap-2">
+            <CheckCircleIcon className="w-5 h-5 text-primary self-start shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0 break-words whitespace-normal leading-5">
+              <MDXRemote
+                source={skill}
+                options={{
+                  mdxOptions: {
+                    rehypePlugins: [rehypeRaw],
+                    remarkPlugins: [remarkGfm],
+                    format: "md",
+                  },
+                }}
+                components={{
+                  p: (props: any) => <p className="m-0">{props.children}</p>,
+                }}
+              />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeSkills.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChallengeSkills.tsx
@@ -13,7 +13,7 @@ export function ChallengeSkills({ skills }: { skills?: string[] }) {
       <div className="mb-3 text-sm font-semibold uppercase tracking-wide text-base-content/70">
         Skills you&apos;ll gain
       </div>
-      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2.5 text-sm">
+      <ul className="space-y-2.5 text-sm">
         {skills.slice(0, 4).map(skill => (
           <li key={skill} className="flex items-start gap-2">
             <CheckCircleIcon className="w-5 h-5 text-primary self-start shrink-0 mt-0.5" />

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/ChatEmptyState.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/ChatEmptyState.tsx
@@ -13,10 +13,17 @@ export function ChatEmptyState({ onSuggestionClick }: { onSuggestionClick: (text
         <ChatBubbleLeftRightIcon className="w-7 h-7 text-primary" />
       </div>
       <div>
-        <p className="font-semibold text-base-content text-sm">Learn the concepts</p>
-        <p className="text-xs text-base-content/50 mt-1 max-w-[260px]">
+        <p className="font-semibold text-base-content text-base">Learn the concepts</p>
+        <p className="text-sm leading-5 text-base-content/55 mt-2 max-w-[300px]">
           Get grounded on the concepts before you dive into the code. I&apos;ll explain what this challenge is about,
           then help you set it up locally.
+        </p>
+        <p className="text-sm leading-5 text-base-content/65 mt-4 max-w-[300px]">
+          You can also use your local IDE with AI context, or follow the{" "}
+          <a href="#ai-guided-learning-mode-optional" className="link link-primary font-medium">
+            AI-guided section
+          </a>
+          .
         </p>
       </div>
       <div className="flex flex-wrap gap-2 mt-1 justify-center">
@@ -24,7 +31,7 @@ export function ChatEmptyState({ onSuggestionClick }: { onSuggestionClick: (text
           <button
             key={suggestion}
             onClick={() => onSuggestionClick(suggestion)}
-            className="text-[11px] px-3 py-1.5 rounded-full border border-primary/20 text-primary hover:bg-primary/10 transition-colors"
+            className="text-xs px-3 py-1.5 rounded-full border border-primary/20 text-primary hover:bg-primary/10 transition-colors"
           >
             {suggestion}
           </button>

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/ChatEmptyState.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/ChatEmptyState.tsx
@@ -6,7 +6,13 @@ const SUGGESTIONS = [
   "I'm getting an error",
 ];
 
-export function ChatEmptyState({ onSuggestionClick }: { onSuggestionClick: (text: string) => void }) {
+export function ChatEmptyState({
+  onSuggestionClick,
+  aiGuidedSectionId,
+}: {
+  onSuggestionClick: (text: string) => void;
+  aiGuidedSectionId?: string;
+}) {
   return (
     <div className="flex flex-col items-center justify-center h-full text-center px-6 gap-4">
       <div className="w-14 h-14 rounded-2xl bg-secondary/40 flex items-center justify-center">
@@ -19,10 +25,15 @@ export function ChatEmptyState({ onSuggestionClick }: { onSuggestionClick: (text
           then help you set it up locally.
         </p>
         <p className="text-sm leading-5 text-base-content/65 mt-4 max-w-[300px]">
-          You can also use your local IDE with AI context, or follow the{" "}
-          <a href="#ai-guided-learning-mode-optional" className="link link-primary font-medium">
-            AI-guided section
-          </a>
+          You can also use your local IDE with AI context
+          {aiGuidedSectionId ? (
+            <>
+              , or follow the{" "}
+              <a href={`#${aiGuidedSectionId}`} className="link link-primary font-medium">
+                AI-guided section
+              </a>
+            </>
+          ) : null}
           .
         </p>
       </div>

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
@@ -116,6 +116,17 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (isOpen) {
+      document.documentElement.dataset.challengeChatOpen = "true";
+      return () => {
+        delete document.documentElement.dataset.challengeChatOpen;
+      };
+    }
+
+    delete document.documentElement.dataset.challengeChatOpen;
+  }, [isOpen]);
+
   if (!isAdmin) return null;
 
   return (
@@ -146,10 +157,10 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
               <SparklesIcon className="w-5 h-5 text-secondary-content" />
             </div>
             <div className="min-w-0">
-              <h3 className="font-semibold text-secondary-content text-sm leading-tight mb-0">AI Teaching Assistant</h3>
-              <p className="text-[11px] text-secondary-content/60 leading-tight m-0">
-                Guides you, won&apos;t give answers
-              </p>
+              <h3 className="font-semibold text-secondary-content text-base leading-tight mb-0">
+                AI Teaching Assistant
+              </h3>
+              <p className="text-xs text-secondary-content/65 leading-tight m-0">Guides you, won&apos;t give answers</p>
             </div>
           </div>
           <div className="flex items-center gap-1 mt-[3px]">

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
@@ -117,17 +117,6 @@ export function ChatWidget({ challengeId, github, aiGuidedSectionId }: ChatWidge
     }
   }, [isOpen]);
 
-  useEffect(() => {
-    if (isOpen) {
-      document.documentElement.dataset.challengeChatOpen = "true";
-      return () => {
-        delete document.documentElement.dataset.challengeChatOpen;
-      };
-    }
-
-    delete document.documentElement.dataset.challengeChatOpen;
-  }, [isOpen]);
-
   if (!isAdmin) return null;
 
   return (

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ChatWidget/index.tsx
@@ -19,9 +19,10 @@ import { useAuthSession } from "~~/hooks/useAuthSession";
 type ChatWidgetProps = {
   challengeId: string;
   github: string;
+  aiGuidedSectionId?: string;
 };
 
-export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
+export function ChatWidget({ challengeId, github, aiGuidedSectionId }: ChatWidgetProps) {
   const { isAdmin } = useAuthSession();
   const [isOpen, setIsOpen] = useState(false);
   const [input, setInput] = useState("");
@@ -191,6 +192,7 @@ export function ChatWidget({ challengeId, github }: ChatWidgetProps) {
             <div ref={contentRef} className="space-y-4">
               {messages.length === 0 && (
                 <ChatEmptyState
+                  aiGuidedSectionId={aiGuidedSectionId}
                   onSuggestionClick={text => {
                     setInput(text);
                     textareaRef.current?.focus();

--- a/packages/nextjs/app/challenge/[challengeId]/_components/ConnectAndRegisterBanner.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/_components/ConnectAndRegisterBanner.tsx
@@ -21,7 +21,7 @@ export const ConnectAndRegisterBanner = () => {
   const isWalletConnected = !!connectedAddress;
 
   return (
-    <div className="fixed bottom-8 inset-x-0 mx-auto w-fit max-w-[100%] md:max-w-[650px] p-2">
+    <div className="fixed bottom-8 inset-x-0 z-50 mx-auto w-fit max-w-[100%] md:max-w-[650px] p-2">
       <div className="bg-base-100 border border-primary/30 rounded-lg p-4 shadow-lg">
         <div className="text-center space-y-3">
           <div className="text-sm font-semibold text-primary">🚀 Ready to submit your challenge?</div>
@@ -33,7 +33,7 @@ export const ConnectAndRegisterBanner = () => {
                   You&apos;re viewing this challenge as a <span className="font-bold">guest</span>. Want to start
                   building your <span className="font-bold">onchain portfolio</span>?
                 </p>
-                <p>
+                <p className="hidden md:block">
                   <span className="font-bold">Connect your wallet and register</span> to unlock the full Speedrun
                   Ethereum experience.
                 </p>
@@ -50,7 +50,7 @@ export const ConnectAndRegisterBanner = () => {
 
           <div className="flex justify-center">
             {!isWalletConnected ? (
-              <RainbowKitCustomConnectButton />
+              <RainbowKitCustomConnectButton size="sm" />
             ) : (
               <button
                 className="flex items-center justify-center py-1.5 lg:py-2 px-3 lg:px-8 border-2 border-primary rounded-full bg-base-300 hover:bg-base-200 transition-colors cursor-pointer"

--- a/packages/nextjs/app/challenge/[challengeId]/page.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/page.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { ChallengeHeader } from "./_components/ChallengeHeader";
 import { ChallengeSidebar } from "./_components/ChallengeSidebar";
+import { ChallengeSkills } from "./_components/ChallengeSkills";
 import { ChatWidget } from "./_components/ChatWidget";
 import { ConnectAndRegisterBanner } from "./_components/ConnectAndRegisterBanner";
 import { Details as MdxDetails, Summary as MdxSummary } from "./_components/MdxDetails";
@@ -125,9 +126,7 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
                   <h1 className="text-3xl lg:text-4xl font-extrabold text-base-content mb-3 leading-tight">
                     {challenge.challengeName}
                   </h1>
-                  {challenge.description && (
-                    <p className="text-[17px] text-base-content/90 m-0 leading-relaxed">{challenge.description}</p>
-                  )}
+                  <ChallengeSkills skills={staticMetadata?.skills} />
                 </div>
               </div>
             </div>
@@ -138,13 +137,12 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
 
             <main className="min-w-0 max-w-[1040px]">
               <ChallengeHeader
-                skills={staticMetadata?.skills}
                 skillLevel={staticMetadata?.skillLevel}
                 timeToComplete={staticMetadata?.timeToComplete}
                 helpfulLinks={staticMetadata?.helpfulLinks}
                 completedByCount={countOfCompletedChallenge}
               >
-                <article className="prose dark:prose-invert max-w-none break-words mt-8">
+                <article className="prose dark:prose-invert max-w-none break-words">
                   <MDXRemote
                     source={restMdx}
                     components={{

--- a/packages/nextjs/app/challenge/[challengeId]/page.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/page.tsx
@@ -128,7 +128,7 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
           <div className="challenge-page-shell px-4 lg:px-6 lg:grid lg:grid-cols-[18rem_minmax(0,1fr)] lg:gap-8 pt-0 pb-10 lg:pb-14">
             <ChallengeSidebar headings={headings} />
 
-            <main className="min-w-0 max-w-[1040px]">
+            <main className="min-w-0 max-w-[850px]">
               <ChallengeHeader
                 skillLevel={staticMetadata?.skillLevel}
                 timeToComplete={staticMetadata?.timeToComplete}

--- a/packages/nextjs/app/challenge/[challengeId]/page.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/page.tsx
@@ -99,11 +99,8 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
               <div className="hidden lg:block" aria-hidden />
               <div className="min-w-0 flex flex-col gap-8 lg:flex-row lg:items-center lg:gap-10">
                 <div className="min-w-0 flex-1 max-w-[640px]">
-                  <div className="mb-2.5 text-sm font-semibold tracking-[0.1em] text-base-content/70">
-                    CHALLENGE #{challenge.sortOrder}
-                  </div>
                   <h1 className="text-3xl lg:text-4xl font-extrabold text-base-content mb-3 leading-tight">
-                    {challenge.challengeName}
+                    Challenge: {challenge.challengeName}
                   </h1>
                   <ChallengeSkills skills={staticMetadata?.skills} />
                 </div>

--- a/packages/nextjs/app/challenge/[challengeId]/page.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/page.tsx
@@ -134,6 +134,7 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
                 timeToComplete={staticMetadata?.timeToComplete}
                 helpfulLinks={staticMetadata?.helpfulLinks}
                 completedByCount={countOfCompletedChallenge}
+                isAiReady={staticMetadata?.isAiReady}
               >
                 <article className="prose dark:prose-invert max-w-none break-words">
                   <MDXRemote

--- a/packages/nextjs/app/challenge/[challengeId]/page.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/page.tsx
@@ -83,6 +83,11 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
   // Extract headings for the sidebar navigation
   const headings = extractHeadings(restMdx);
 
+  // The chat empty state links to the readme's AI-guided section; derive the anchor from the
+  // extracted headings (same ids the sidebar uses) so the link can't drift, and omit it when
+  // the readme has no such section.
+  const aiGuidedSectionId = headings.find(heading => heading.id.includes("ai-guided"))?.id;
+
   // Custom h2 component that adds IDs for anchor navigation
   const createH2WithId = ({ children, ...props }: { children?: ReactNode }) => {
     const text = String(children);
@@ -196,7 +201,7 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
         </div>
       )}
       {staticMetadata?.isAiReady && challenge.github && (
-        <ChatWidget challengeId={challenge.id} github={challenge.github} />
+        <ChatWidget challengeId={challenge.id} github={challenge.github} aiGuidedSectionId={aiGuidedSectionId} />
       )}
     </div>
   );

--- a/packages/nextjs/app/challenge/[challengeId]/page.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/page.tsx
@@ -1,5 +1,6 @@
 import { createElement } from "react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import Image from "next/image";
 import { notFound } from "next/navigation";
 import { ChallengeHeader } from "./_components/ChallengeHeader";
 import { ChallengeSidebar } from "./_components/ChallengeSidebar";
@@ -75,7 +76,7 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
 
   const rawReadme = await fetchGithubChallengeReadme(challenge.github);
   const challengeReadme = prepareMdxReadme(rawReadme);
-  const { headerImageMdx, restMdx } = splitChallengeReadme(challengeReadme);
+  const { restMdx } = splitChallengeReadme(challengeReadme);
   const { owner, repo, branch } = parseGithubUrl(challenge.github);
 
   // Extract headings for the sidebar navigation
@@ -89,90 +90,125 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
   };
 
   return (
-    <div className="flex relative max-w-[100vw]">
-      {/* Sidebar Navigation */}
-      <ChallengeSidebar headings={headings} />
-
-      {/* Main Content */}
-      <div className="flex-1 flex flex-col items-center py-8 px-5 xl:p-12">
-        {challengeReadme ? (
-          <>
-            <div className="prose dark:prose-invert max-w-fit break-words lg:max-w-[850px]">
-              <MDXRemote
-                source={headerImageMdx}
-                components={{ Tabs: MdxTabs, Tab: MdxTab, Details: MdxDetails, Summary: MdxSummary }}
-                options={mdxRemoteOptions}
-              />
-            </div>
-            <ChallengeHeader
-              skills={staticMetadata?.skills}
-              skillLevel={staticMetadata?.skillLevel}
-              timeToComplete={staticMetadata?.timeToComplete}
-              helpfulLinks={staticMetadata?.helpfulLinks}
-              completedByCount={countOfCompletedChallenge}
-              isAiReady={staticMetadata?.isAiReady}
-            />
-            <div className="prose dark:prose-invert max-w-fit break-words lg:max-w-[850px]">
-              <MDXRemote
-                source={restMdx}
-                components={{
-                  a: (props: ComponentPropsWithoutRef<"a">) =>
-                    createElement("a", { ...props, target: "_blank", rel: "noopener" }),
-                  h2: createH2WithId,
-                  Tabs: MdxTabs,
-                  Tab: MdxTab,
-                  Details: MdxDetails,
-                  Summary: MdxSummary,
-                }}
-                options={mdxRemoteOptions}
-              />
-            </div>
-
-            <a
-              href={`https://github.com/${owner}/${repo}/tree/${branch}`}
-              className="block mt-2"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <button className="btn btn-outline btn-sm sm:btn-md">
-                <span className="text-xs sm:text-sm">View on GitHub</span>
-                <ArrowTopRightOnSquareIcon className="w-3 h-3 sm:w-4 sm:h-4" />
-              </button>
-            </a>
-            {guides && guides.length > 0 && (
-              <div className="max-w-[850px] w-full mx-auto">
-                <div className="mt-16 mb-4 font-semibold text-left">Related guides</div>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2 mb-2">
-                  {guides.map(guide => (
-                    <div key={guide.url} className="p-4 border rounded bg-base-300">
-                      <a href={guide.url} className="text-primary underline font-semibold">
-                        {guide.title}
-                      </a>
-                    </div>
-                  ))}
+    <div className="relative max-w-[100vw]">
+      {challengeReadme ? (
+        <>
+          <div className="overflow-hidden bg-[#A8E7F4] dark:bg-[#015555] py-10 lg:py-12">
+            <div className="challenge-page-shell px-4 lg:px-6 lg:grid lg:grid-cols-[18rem_minmax(0,1fr)] lg:gap-8">
+              <div className="hidden lg:flex items-center justify-center pr-2" aria-hidden>
+                {challenge.previewImage && (
+                  <Image
+                    src={challenge.previewImage}
+                    alt=""
+                    width={270}
+                    height={200}
+                    className="w-full max-w-[250px] h-auto object-contain drop-shadow-[0_10px_14px_rgba(0,109,119,0.18)]"
+                    priority
+                  />
+                )}
+              </div>
+              <div className="relative min-w-0">
+                {challenge.previewImage && (
+                  <Image
+                    src={challenge.previewImage}
+                    alt=""
+                    width={520}
+                    height={380}
+                    className="pointer-events-none absolute -right-12 -top-16 hidden w-[430px] max-w-none opacity-[0.12] lg:block dark:opacity-[0.08]"
+                    aria-hidden
+                  />
+                )}
+                <div className="relative z-10 min-w-0 max-w-[760px]">
+                  <div className="mb-2.5 text-sm font-semibold tracking-[0.1em] text-base-content/70">
+                    CHALLENGE #{challenge.sortOrder}
+                  </div>
+                  <h1 className="text-3xl lg:text-4xl font-extrabold text-base-content mb-3 leading-tight">
+                    {challenge.challengeName}
+                  </h1>
+                  {challenge.description && (
+                    <p className="text-[17px] text-base-content/90 m-0 leading-relaxed">{challenge.description}</p>
+                  )}
                 </div>
               </div>
-            )}
-          </>
-        ) : (
-          <div>Failed to load challenge content</div>
-        )}
-        {challenge.autograding && (
-          <>
-            <ConnectAndRegisterBanner />
-            <SubmitChallengeButton challengeId={challenge.id} />
-          </>
-        )}
-        {challenge.externalLink && (
-          <div className="fixed bottom-8 inset-x-0 mx-auto w-fit">
-            <button className="btn btn-sm sm:btn-md btn-primary text-secondary px-3 sm:px-4 mt-2 text-xs sm:text-sm">
-              <a href={challenge.externalLink.link} target="_blank" rel="noopener noreferrer">
-                {challenge.externalLink.claim}
-              </a>
-            </button>
+            </div>
           </div>
-        )}
-      </div>
+
+          <div className="challenge-page-shell px-4 lg:px-6 lg:grid lg:grid-cols-[18rem_minmax(0,1fr)] lg:gap-8 pt-0 pb-10 lg:pb-14">
+            <ChallengeSidebar headings={headings} />
+
+            <main className="min-w-0 max-w-[1040px]">
+              <ChallengeHeader
+                skills={staticMetadata?.skills}
+                skillLevel={staticMetadata?.skillLevel}
+                timeToComplete={staticMetadata?.timeToComplete}
+                helpfulLinks={staticMetadata?.helpfulLinks}
+                completedByCount={countOfCompletedChallenge}
+              >
+                <article className="prose dark:prose-invert max-w-none break-words mt-8">
+                  <MDXRemote
+                    source={restMdx}
+                    components={{
+                      a: (props: ComponentPropsWithoutRef<"a">) =>
+                        createElement("a", { ...props, target: "_blank", rel: "noopener" }),
+                      h2: createH2WithId,
+                      Tabs: MdxTabs,
+                      Tab: MdxTab,
+                      Details: MdxDetails,
+                      Summary: MdxSummary,
+                    }}
+                    options={mdxRemoteOptions}
+                  />
+                </article>
+
+                <a
+                  href={`https://github.com/${owner}/${repo}/tree/${branch}`}
+                  className="block mt-2"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <button className="btn btn-outline btn-sm sm:btn-md">
+                    <span className="text-xs sm:text-sm">View on GitHub</span>
+                    <ArrowTopRightOnSquareIcon className="w-3 h-3 sm:w-4 sm:h-4" />
+                  </button>
+                </a>
+                {guides && guides.length > 0 && (
+                  <div className="w-full">
+                    <div className="mt-16 mb-4 font-semibold text-left">Related guides</div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2 mb-2">
+                      {guides.map(guide => (
+                        <div key={guide.url} className="p-4 border rounded bg-base-300">
+                          <a href={guide.url} className="text-primary underline font-semibold">
+                            {guide.title}
+                          </a>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {challenge.autograding && (
+                  <>
+                    <ConnectAndRegisterBanner />
+                    <SubmitChallengeButton challengeId={challenge.id} />
+                  </>
+                )}
+              </ChallengeHeader>
+            </main>
+          </div>
+        </>
+      ) : (
+        <div className="px-5 py-8">Failed to load challenge content</div>
+      )}
+
+      {challenge.externalLink && (
+        <div className="fixed bottom-8 inset-x-0 mx-auto w-fit">
+          <button className="btn btn-sm sm:btn-md btn-primary text-secondary px-3 sm:px-4 mt-2 text-xs sm:text-sm">
+            <a href={challenge.externalLink.link} target="_blank" rel="noopener noreferrer">
+              {challenge.externalLink.claim}
+            </a>
+          </button>
+        </div>
+      )}
       {staticMetadata?.isAiReady && challenge.github && (
         <ChatWidget challengeId={challenge.id} github={challenge.github} />
       )}

--- a/packages/nextjs/app/challenge/[challengeId]/page.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/page.tsx
@@ -94,32 +94,11 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
     <div className="relative max-w-[100vw]">
       {challengeReadme ? (
         <>
-          <div className="overflow-hidden bg-[#A8E7F4] dark:bg-[#015555] py-10 lg:py-12">
+          <div className="bg-white dark:bg-[#015555] py-10 lg:py-12">
             <div className="challenge-page-shell px-4 lg:px-6 lg:grid lg:grid-cols-[18rem_minmax(0,1fr)] lg:gap-8">
-              <div className="hidden lg:flex items-center justify-center pr-2" aria-hidden>
-                {challenge.previewImage && (
-                  <Image
-                    src={challenge.previewImage}
-                    alt=""
-                    width={270}
-                    height={200}
-                    className="w-full max-w-[250px] h-auto object-contain drop-shadow-[0_10px_14px_rgba(0,109,119,0.18)]"
-                    priority
-                  />
-                )}
-              </div>
-              <div className="relative min-w-0">
-                {challenge.previewImage && (
-                  <Image
-                    src={challenge.previewImage}
-                    alt=""
-                    width={520}
-                    height={380}
-                    className="pointer-events-none absolute -right-12 -top-16 hidden w-[430px] max-w-none opacity-[0.12] lg:block dark:opacity-[0.08]"
-                    aria-hidden
-                  />
-                )}
-                <div className="relative z-10 min-w-0 max-w-[760px]">
+              <div className="hidden lg:block" aria-hidden />
+              <div className="min-w-0 flex flex-col gap-8 lg:flex-row lg:items-center lg:gap-10">
+                <div className="min-w-0 flex-1 max-w-[640px]">
                   <div className="mb-2.5 text-sm font-semibold tracking-[0.1em] text-base-content/70">
                     CHALLENGE #{challenge.sortOrder}
                   </div>
@@ -128,6 +107,18 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
                   </h1>
                   <ChallengeSkills skills={staticMetadata?.skills} />
                 </div>
+                {challenge.previewImage && (
+                  <div className="shrink-0 flex justify-center lg:justify-end">
+                    <Image
+                      src={challenge.previewImage}
+                      alt=""
+                      width={440}
+                      height={330}
+                      className="w-full max-w-[300px] lg:max-w-[360px] h-auto object-contain"
+                      priority
+                    />
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
@@ -21,7 +21,7 @@ import { getBlockExplorerAddressLink } from "~~/utils/scaffold-eth";
 /**
  * Custom Wagmi Connect Button (watch balance + custom design)
  */
-export const RainbowKitCustomConnectButton = () => {
+export const RainbowKitCustomConnectButton = ({ size = "md" }: { size?: "sm" | "md" }) => {
   const { targetNetwork } = useTargetNetwork();
   const { address: connectedAddress } = useAccount();
   const { data: user, isLoading: isLoadingUser } = useUser(connectedAddress);
@@ -56,7 +56,11 @@ export const RainbowKitCustomConnectButton = () => {
         if (!connected) {
           return (
             <button
-              className="flex items-center py-1.5 lg:py-2 px-3 lg:px-4 border-2 border-primary rounded-full bg-base-300 hover:bg-base-200 transition-colors cursor-pointer"
+              className={`flex items-center border-2 border-primary rounded-full bg-base-300 hover:bg-base-200 transition-colors cursor-pointer ${
+                size === "sm"
+                  ? "py-1 px-3 text-sm md:py-1.5 md:text-base lg:py-2 lg:px-4"
+                  : "py-1.5 lg:py-2 px-3 lg:px-4"
+              }`}
               onClick={openConnectModal}
               data-testid="connect-button"
               type="button"

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -11,6 +11,35 @@ body {
   min-height: 100vh;
 }
 
+.challenge-page-shell {
+  width: 100%;
+  max-width: 1400px;
+  margin-left: auto;
+  margin-right: auto;
+  transition:
+    margin-left 300ms ease,
+    margin-right 300ms ease;
+}
+
+@media (min-width: 1024px) {
+  html[data-challenge-chat-open="true"] .challenge-page-shell {
+    margin-left: 4rem;
+    margin-right: 0;
+  }
+}
+
+@media (min-width: 1280px) {
+  html[data-challenge-chat-open="true"] .challenge-page-shell {
+    margin-left: 5rem;
+  }
+}
+
+@media (min-width: 1536px) {
+  html[data-challenge-chat-open="true"] .challenge-page-shell {
+    margin-left: 6rem;
+  }
+}
+
 h1,
 h2,
 h3,

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -16,27 +16,14 @@ body {
   max-width: 1400px;
   margin-left: auto;
   margin-right: auto;
-  transition:
-    margin-left 300ms ease,
-    margin-right 300ms ease;
 }
 
+/* When the chat panel (420px, fixed right) is open, reserve its width instead of shifting the
+   shell: width auto + margin-right can never overflow the viewport, unlike width 100% + margin. */
 @media (min-width: 1024px) {
   html[data-challenge-chat-open="true"] .challenge-page-shell {
-    margin-left: 4rem;
-    margin-right: 0;
-  }
-}
-
-@media (min-width: 1280px) {
-  html[data-challenge-chat-open="true"] .challenge-page-shell {
-    margin-left: 5rem;
-  }
-}
-
-@media (min-width: 1536px) {
-  html[data-challenge-chat-open="true"] .challenge-page-shell {
-    margin-left: 6rem;
+    width: auto;
+    margin-right: calc(420px + 1rem);
   }
 }
 

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -18,14 +18,6 @@ body {
   margin-right: auto;
 }
 
-/* Reserve the open chat panel's width (420px) on viewports wide enough to fit both; below 2xl it overlays. */
-@media (min-width: 1536px) {
-  html[data-challenge-chat-open="true"] .challenge-page-shell {
-    width: auto;
-    margin-right: calc(420px + 1rem);
-  }
-}
-
 /* Thin TOC scrollbar whose thumb only shows while hovering the nav. */
 .toc-scrollbar {
   scrollbar-width: thin; /* Firefox */

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -18,13 +18,31 @@ body {
   margin-right: auto;
 }
 
-/* When the chat panel (420px, fixed right) is open, reserve its width instead of shifting the
-   shell: width auto + margin-right can never overflow the viewport, unlike width 100% + margin. */
-@media (min-width: 1024px) {
+/* Reserve the open chat panel's width (420px) on viewports wide enough to fit both; below 2xl it overlays. */
+@media (min-width: 1536px) {
   html[data-challenge-chat-open="true"] .challenge-page-shell {
     width: auto;
     margin-right: calc(420px + 1rem);
   }
+}
+
+/* Thin TOC scrollbar whose thumb only shows while hovering the nav. */
+.toc-scrollbar {
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: transparent transparent;
+}
+.toc-scrollbar:hover {
+  scrollbar-color: oklch(var(--bc) / 0.25) transparent;
+}
+.toc-scrollbar::-webkit-scrollbar {
+  width: 6px; /* Chrome/Edge/Safari */
+}
+.toc-scrollbar::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 3px;
+}
+.toc-scrollbar:hover::-webkit-scrollbar-thumb {
+  background: oklch(var(--bc) / 0.25);
 }
 
 h1,


### PR DESCRIPTION
Tried to redesign the challenge layout to be more inline with the new version of the guides layout from #390 

- In the hero i tried to have clean layout with title + skills and challenge compact image in the right, used white background to have nice contrast with the greens from the challenge images. 
Having the skills at the top gives us a nice summary of what's the challenge about, and it's cleaner to add the image to the right.
- Deleted the AI assisted / guided paragraph, and added a sentence in the AI Teacher chat on its empty state, with a link to the AI-Guided section of the readme (if exists). 
   - Maybe we should add some kind of text to the AI Teacher button to make it more visible so whoever wants assistance, finds it easily.
- Increased the size of the font of the empty state chat because it felt a bit too small
- Pushed the content to the left if the user opens the AI Teacher panel

## Summary

Reworks the per-challenge page into a more structured, scannable layout:

- **Hero** with a clean "Challenge: {name}" title (no emojis), the "Skills you'll gain" list in a single column, and the challenge preview image full-size beside them. White background in light mode so the pixel-art images read as designed; dark teal in dark mode.
- **Facts bar** — skill level, time to complete, completed-by count, and helpful links pulled into a single card that overlaps the hero.
- **Content card** — the full readme body (intro paragraph included), "View on GitHub", related guides, and submit/register actions flow inside one card.
- **Sidebar** ("On this page") restyled with a continuous left rule and sticky positioning; it reserves its column on large screens even when empty so the content doesn't jump, and long TOCs get a thin hover-only scrollbar instead of the OS default.
- **AI chat widget**: below 2xl the open panel overlays the content (like mobile); at 2xl+ the page reserves the panel's width (`data-challenge-chat-open` + `.challenge-page-shell` in `globals.css`). Copy/sizing polish in the header and empty state; the empty state's "AI-guided section" link is derived from the readme's extracted headings (same ids the sidebar uses) and hidden when the section is absent.

**Chat gating is intentionally unchanged (admin-only).** Opening the assistant to users + rate limiting is handled separately in #389, so this PR deliberately leaves `api/chat/route.ts` and the widget's auth gate as they are on `main` to avoid overlapping with that work.

## How to test

1. `cd packages/nextjs && yarn start`
2. Open any challenge page (e.g. an AI-ready one) and check:
   - Hero shows the "Challenge: {name}" title, skills list, and preview image (light + dark mode).
   - Facts bar renders and wraps correctly on mobile and desktop.
   - "On this page" sidebar scroll-spy still works; on a long TOC (e.g. stablecoins) the scrollbar only appears on hover.
3. As an admin, open the AI chat widget: at ≥1536px wide the content shifts left to make room; below that the panel overlays the page. No horizontal scrollbar at any width.

## Notes for reviewers

- Touches the same two chat files as #389 (`api/chat/route.ts`, `ChatWidget/index.tsx`) but only the widget's visual bits — the auth gate and route are identical to `main`. Whichever of the two PRs merges second, the chat-related overlap should be trivial.
- `ChallengeHeader` now takes `children` (the challenge body + actions) instead of rendering the AI-ready blurb; the `isAiReady` prop was removed from the header. Known follow-up: non-admin users currently see no "AI-ready / run `/start`" messaging on AI-ready challenges (the old info card was removed and the chat widget is admin-gated) — to be addressed here or after #389.
- `splitChallengeReadme`'s `headerImageMdx` is no longer rendered (the hero renders the title directly); the readme body is rendered in full, with the readme H1 stripped only when followed by the header image, per current readme convention.