### PR TITLE
Add Course and ItemList structured data to homepage and challenges

### DIFF
--- a/packages/nextjs/app/challenge/[challengeId]/page.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/page.tsx
@@ -23,6 +23,7 @@ import {
 import { fetchGithubChallengeReadme, parseGithubUrl, prepareMdxReadme, splitChallengeReadme } from "~~/services/github";
 import { CHALLENGE_METADATA, extractHeadings, generateHeadingId } from "~~/utils/challenges";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
+import { getChallengeStructuredData } from "~~/utils/structuredData";
 
 const mdxRemoteOptions: MDXRemoteProps["options"] = {
   mdxOptions: {
@@ -71,6 +72,12 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
   const guides = staticMetadata?.guides;
   const countOfCompletedChallenge = await getCountOfCompletedChallenge(challenge.id as ChallengeId);
 
+  const structuredData = getChallengeStructuredData({
+    id: challenge.id,
+    name: challenge.challengeName,
+    description: staticMetadata?.description || challenge.description,
+  });
+
   if (!challenge.github) {
     return <div>No challenge content available</div>;
   }
@@ -97,6 +104,7 @@ export default async function ChallengePage(props: { params: Promise<{ challenge
 
   return (
     <div className="relative max-w-[100vw]">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
       {challengeReadme ? (
         <>
           <div className="bg-white dark:bg-[#015555] py-10 lg:py-12">

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -2,6 +2,7 @@ import { HomepageClient } from "./_components/HomepageClient";
 import { NextPage } from "next";
 import { getAllChallenges } from "~~/services/database/repositories/challenges";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
+import { getHomepageStructuredData } from "~~/utils/structuredData";
 
 export const metadata = getMetadata({
   title: "Speedrun Ethereum: Learn Solidity Development Through Interactive Challenges",
@@ -11,8 +12,16 @@ export const metadata = getMetadata({
 
 const Home: NextPage = async () => {
   const challenges = await getAllChallenges();
+  const structuredData = getHomepageStructuredData(challenges);
 
-  return <HomepageClient challenges={challenges} />;
+  return (
+    <>
+      {structuredData.map((schema, index) => (
+        <script key={index} type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      ))}
+      <HomepageClient challenges={challenges} />
+    </>
+  );
 };
 
 export default Home;

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -4,16 +4,18 @@ import { getAllChallenges } from "~~/services/database/repositories/challenges";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 import { getHomepageStructuredData } from "~~/utils/structuredData";
 
+const HOMEPAGE_DESCRIPTION =
+  "Learn Solidity development with hands-on blockchain challenges. Build NFTs, DEXs, and more Ethereum smart contracts in our step-by-step tutorial series.";
+
 export const metadata = getMetadata({
   title: "Speedrun Ethereum: Learn Solidity Development Through Interactive Challenges",
-  description:
-    "Learn Solidity development with hands-on blockchain challenges. Build NFTs, DEXs, and more Ethereum smart contracts in our step-by-step tutorial series.",
+  description: HOMEPAGE_DESCRIPTION,
   path: "/",
 });
 
 const Home: NextPage = async () => {
   const challenges = await getAllChallenges();
-  const structuredData = getHomepageStructuredData(challenges);
+  const structuredData = getHomepageStructuredData(challenges, HOMEPAGE_DESCRIPTION);
 
   return (
     <>

--- a/packages/nextjs/utils/structuredData.ts
+++ b/packages/nextjs/utils/structuredData.ts
@@ -1,0 +1,67 @@
+import { Challenges } from "~~/services/database/repositories/challenges";
+
+const SITE_URL = "https://speedrunethereum.com";
+const COURSE_NAME = "Speedrun Ethereum";
+const COURSE_DESCRIPTION =
+  "Learn Solidity development by building real dapps through hands-on Ethereum challenges, from your first NFT to a DEX, oracles, stablecoins, and more.";
+
+const provider = {
+  "@type": "Organization",
+  name: "BuidlGuidl",
+  url: "https://buidlguidl.com",
+};
+
+// Homepage: the whole curriculum as a Course plus an ordered ItemList of its challenges.
+export function getHomepageStructuredData(challenges: Challenges) {
+  const orderedChallenges = challenges
+    .filter(challenge => !challenge.disabled)
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+
+  const course = {
+    "@context": "https://schema.org",
+    "@type": "Course",
+    name: COURSE_NAME,
+    description: COURSE_DESCRIPTION,
+    url: SITE_URL,
+    provider,
+  };
+
+  const itemList = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "Speedrun Ethereum Challenges",
+    itemListElement: orderedChallenges.map((challenge, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: `${SITE_URL}/challenge/${challenge.id}`,
+      name: challenge.challengeName,
+    })),
+  };
+
+  return [course, itemList];
+}
+
+// Challenge page: a Course node for a single challenge, tied back to the curriculum.
+export function getChallengeStructuredData({
+  id,
+  name,
+  description,
+}: {
+  id: string;
+  name: string;
+  description: string;
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Course",
+    name,
+    description,
+    url: `${SITE_URL}/challenge/${id}`,
+    provider,
+    isPartOf: {
+      "@type": "Course",
+      name: COURSE_NAME,
+      url: SITE_URL,
+    },
+  };
+}

--- a/packages/nextjs/utils/structuredData.ts
+++ b/packages/nextjs/utils/structuredData.ts
@@ -2,8 +2,8 @@ import { Challenges } from "~~/services/database/repositories/challenges";
 
 const SITE_URL = "https://speedrunethereum.com";
 const COURSE_NAME = "Speedrun Ethereum";
-const COURSE_DESCRIPTION =
-  "Learn Solidity development by building real dapps through hands-on Ethereum challenges, from your first NFT to a DEX, oracles, stablecoins, and more.";
+// Canonical node id so the homepage Course and each challenge's `isPartOf` resolve to the same entity.
+const COURSE_ID = `${SITE_URL}/#course`;
 
 const provider = {
   "@type": "Organization",
@@ -12,7 +12,8 @@ const provider = {
 };
 
 // Homepage: the whole curriculum as a Course plus an ordered ItemList of its challenges.
-export function getHomepageStructuredData(challenges: Challenges) {
+// `description` is sourced from the homepage metadata so the two never drift.
+export function getHomepageStructuredData(challenges: Challenges, description: string) {
   const orderedChallenges = challenges
     .filter(challenge => !challenge.disabled)
     .sort((a, b) => a.sortOrder - b.sortOrder);
@@ -20,8 +21,9 @@ export function getHomepageStructuredData(challenges: Challenges) {
   const course = {
     "@context": "https://schema.org",
     "@type": "Course",
+    "@id": COURSE_ID,
     name: COURSE_NAME,
-    description: COURSE_DESCRIPTION,
+    description,
     url: SITE_URL,
     provider,
   };
@@ -33,8 +35,11 @@ export function getHomepageStructuredData(challenges: Challenges) {
     itemListElement: orderedChallenges.map((challenge, index) => ({
       "@type": "ListItem",
       position: index + 1,
-      url: `${SITE_URL}/challenge/${challenge.id}`,
-      name: challenge.challengeName,
+      item: {
+        "@type": "Course",
+        name: challenge.challengeName,
+        url: `${SITE_URL}/challenge/${challenge.id}`,
+      },
     })),
   };
 
@@ -59,9 +64,7 @@ export function getChallengeStructuredData({
     url: `${SITE_URL}/challenge/${id}`,
     provider,
     isPartOf: {
-      "@type": "Course",
-      name: COURSE_NAME,
-      url: SITE_URL,
+      "@id": COURSE_ID,
     },
   };
 }


### PR DESCRIPTION
## Summary

Only guide pages emit JSON-LD today (`FAQPage`, in `app/guides/[slug]/page.tsx`). The homepage and challenge pages, which are the learning product itself, emit none, so parsers can't recognize "Speedrun Ethereum" as a structured course with an ordered curriculum.

This adds `schema.org` structured data via `<script type="application/ld+json">`, reusing the existing guides pattern:

- **Homepage:** a `Course` node (provider: BuidlGuidl) plus an `ItemList` of the challenges in curriculum order, built from the live `challenges` data and sorted by `sortOrder` (disabled challenges excluded).
- **Challenge pages:** a per-challenge `Course` node marked `isPartOf` the overall Speedrun Ethereum course, using the same title/description as the page metadata.
- New helper `utils/structuredData.ts` keeps the markup out of the page components.
- The existing guide FAQ schema is unchanged.

For example, `/challenge/dex` returns the following structured data:
```
{
  "@context": "https://schema.org",
  "@type": "Course",
  "name": "Build a DEX",
  "description": "Step-by-step tutorial to build your own DEX with liquidity pools, token swapping, and automated market making in Solidity.",
  "url": "https://speedrunethereum.com/challenge/dex",
  "provider": {
    "@type": "Organization",
    "name": "BuidlGuidl",
    "url": "https://buidlguidl.com"
  },
  "isPartOf": {
    "@type": "Course",
    "name": "Speedrun Ethereum",
    "url": "https://speedrunethereum.com"
  }
}
```

## How to test

1. `cd packages/nextjs && yarn dev`
2. View source on `/` and confirm two `application/ld+json` blocks: a `Course` and an `ItemList` whose items match the real challenge order.
3. Open any `/challenge/<id>` and confirm a `Course` block with `isPartOf` pointing back to the curriculum.
4. Paste either into the [schema.org validator](https://validator.schema.org/) and confirm it parses with no errors.