### PR TITLE
Add homepage H1 and self-referencing canonical URLs

### DIFF
--- a/packages/nextjs/app/_components/Hero.tsx
+++ b/packages/nextjs/app/_components/Hero.tsx
@@ -12,7 +12,7 @@ export const Hero = () => {
           <HeroDiamond className="h-12 w-12" />
         </div>
 
-        <h1 className="text-center mb-5  dark:text-gray-200">
+        <h1 className="text-center mt-4 mb-5 leading-normal dark:text-gray-200">
           Learn how to build on <strong>Ethereum</strong>; the superpowers and the gotchas.
         </h1>
 

--- a/packages/nextjs/app/_components/Hero.tsx
+++ b/packages/nextjs/app/_components/Hero.tsx
@@ -12,9 +12,9 @@ export const Hero = () => {
           <HeroDiamond className="h-12 w-12" />
         </div>
 
-        <p className="text-center mb-5  dark:text-gray-200">
+        <h1 className="text-center mb-5  dark:text-gray-200">
           Learn how to build on <strong>Ethereum</strong>; the superpowers and the gotchas.
-        </p>
+        </h1>
 
         <div className="mb-10 lg:mb-5 mt-4 w-full flex justify-center">
           <HeroLogo className="max-w-[600px]" />

--- a/packages/nextjs/app/build-prompts/page.tsx
+++ b/packages/nextjs/app/build-prompts/page.tsx
@@ -7,6 +7,7 @@ export const metadata = getMetadata({
   description:
     "Full project specs for AI coding agents. Pick a build, copy the prompt into your AI, and customize the parameters to scaffold a working dApp on Scaffold-ETH 2.",
   imageRelativePath: "/build-prompts-thumbnail.png",
+  path: "/build-prompts",
 });
 
 export default function BuildPromptsPage() {

--- a/packages/nextjs/app/builds/page.tsx
+++ b/packages/nextjs/app/builds/page.tsx
@@ -5,6 +5,7 @@ import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 export const metadata = getMetadata({
   title: "All Builds",
   description: "View all the builds by the Speedrun Ethereum community",
+  path: "/builds",
 });
 
 export default async function AllBuildsPage(props: {

--- a/packages/nextjs/app/challenge/[challengeId]/page.tsx
+++ b/packages/nextjs/app/challenge/[challengeId]/page.tsx
@@ -57,6 +57,7 @@ export async function generateMetadata(props: { params: Promise<{ challengeId: s
     title: staticMetadata?.title || challenge?.challengeName || "",
     description: staticMetadata?.description || challenge?.description || "",
     imageRelativePath: challenge?.previewImage || undefined,
+    path: `/challenge/${params.challengeId}`,
   });
 }
 

--- a/packages/nextjs/app/guides/[slug]/page.tsx
+++ b/packages/nextjs/app/guides/[slug]/page.tsx
@@ -19,6 +19,7 @@ export async function generateMetadata(props: { params: Promise<{ slug: string }
     title: guide.title,
     description: guide.description,
     imageRelativePath: guide.image,
+    path: `/guides/${params.slug}`,
   });
 }
 

--- a/packages/nextjs/app/guides/page.tsx
+++ b/packages/nextjs/app/guides/page.tsx
@@ -6,6 +6,7 @@ export const metadata = getMetadata({
   title: "Solidity Tutorials and Guides",
   description:
     "Discover in-depth Solidity tutorials and guides to help you become a blockchain developer. Learn Solidity programming, smart contract development, and best practices for building on Ethereum.",
+  path: "/guides",
 });
 
 export default async function GuidesPage() {

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -7,6 +7,7 @@ export const metadata = getMetadata({
   title: "Speedrun Ethereum: Learn Solidity Development Through Interactive Challenges",
   description:
     "Learn Solidity development with hands-on blockchain challenges. Build NFTs, DEXs, and more Ethereum smart contracts in our step-by-step tutorial series.",
+  path: "/",
 });
 
 const Home: NextPage = async () => {

--- a/packages/nextjs/app/start/page.tsx
+++ b/packages/nextjs/app/start/page.tsx
@@ -25,6 +25,7 @@ export const metadata = getMetadata({
   title: "Build your first Apps on Ethereum",
   description:
     "Build your first Ethereum apps with hands-on challenges. Learn smart contracts and dapp development through real, practical experience.",
+  path: "/start",
 });
 
 const StartLandingPage = async () => {

--- a/packages/nextjs/utils/scaffold-eth/getMetadata.ts
+++ b/packages/nextjs/utils/scaffold-eth/getMetadata.ts
@@ -10,10 +10,12 @@ export const getMetadata = ({
   title,
   description,
   imageRelativePath = "/thumbnail.png",
+  path,
 }: {
   title: string;
   description: string;
   imageRelativePath?: string;
+  path?: string;
 }): Metadata => {
   const imageUrl = `${baseUrl}${imageRelativePath}`;
 
@@ -24,6 +26,8 @@ export const getMetadata = ({
       template: titleTemplate,
     },
     description: description,
+    // Self-referencing canonical, resolved against metadataBase by Next.
+    ...(path ? { alternates: { canonical: path } } : {}),
     openGraph: {
       title: {
         default: title,


### PR DESCRIPTION
## Summary

Two baseline crawl/SEO gaps from the audit:

- **Homepage had no `<h1>`.** `Hero.tsx` rendered the tagline as a `<p>`. Promoted it to a semantic `<h1>`.
- **No self-referencing canonicals.** `getMetadata` emitted no canonical (only `/learn-solidity` set one manually). Added an optional `path` param to `getMetadata` that sets `alternates: { canonical: path }`, resolved against the existing `metadataBase`, and wired it through the content pages.

`/learn-solidity` keeps its existing canonical. Dev-only pages (`/debug`, `/blockexplorer`) are excluded.

## How to test

1. `cd packages/nextjs && yarn dev`
2. View source on `/`: exactly one `<h1>`, and `<link rel="canonical" href=".../">`.
3. Open a challenge and a guide: each has a `<link rel="canonical">` pointing at its own URL.