### PR TITLE
Self-identify Speedrun Ethereum in challenge, guide, and landing copy

### DIFF
--- a/packages/nextjs/app/build-prompts/_components/BuildPrompts.tsx
+++ b/packages/nextjs/app/build-prompts/_components/BuildPrompts.tsx
@@ -126,8 +126,8 @@ export function BuildPrompts({ prompts }: { prompts: BuildPrompt[] }) {
     <div className="py-12 px-6 max-w-6xl mx-auto w-full">
       <h1 className="m-0 text-2xl font-bold lg:text-4xl text-center">Build Prompts</h1>
       <p className="mt-4 text-base-content/70 text-center max-w-2xl mx-auto">
-        Full project specs for AI coding agents. Pick a build, copy the prompt into your favorite AI (Claude, Cursor,
-        Codex, etc.), and tweak the parameters to scaffold a working dApp on{" "}
+        Full project specs for AI coding agents, from Speedrun Ethereum. Pick a build, copy the prompt into your
+        favorite AI (Claude, Cursor, Codex, etc.), and tweak the parameters to scaffold a working dApp on{" "}
         <a href="https://scaffoldeth.io" target="_blank" rel="noopener noreferrer" className="link">
           Scaffold-ETH 2
         </a>

--- a/packages/nextjs/app/build-prompts/page.tsx
+++ b/packages/nextjs/app/build-prompts/page.tsx
@@ -5,7 +5,7 @@ import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 export const metadata = getMetadata({
   title: "Build Prompts",
   description:
-    "Full project specs for AI coding agents. Pick a build, copy the prompt into your AI, and customize the parameters to scaffold a working dApp on Scaffold-ETH 2.",
+    "Free, AI-ready project specs from Speedrun Ethereum. Pick a build, copy the prompt into your AI, and customize the parameters to scaffold a working dApp on Scaffold-ETH 2.",
   imageRelativePath: "/build-prompts-thumbnail.png",
   path: "/build-prompts",
 });

--- a/packages/nextjs/app/learn-solidity/_components/HeroSection.tsx
+++ b/packages/nextjs/app/learn-solidity/_components/HeroSection.tsx
@@ -11,8 +11,8 @@ export const HeroSection = () => {
           <span className="text-primary"> Web3 Developer Course</span>
         </h1>
         <p className="mt-6 max-w-3xl mx-auto text-base-content/80 md:text-lg">
-          Master Solidity with our hands-on tutorials. Build real dApps, complete interactive challenges, and create
-          your on-chain developer portfolio.
+          Master Solidity on Speedrun Ethereum with hands-on tutorials. Build real dApps, complete interactive
+          challenges, and create your on-chain developer portfolio.
         </p>
         <div className="mt-6 flex flex-wrap justify-center gap-6 text-sm text-base-content/70">
           <div className="flex items-center gap-2">

--- a/packages/nextjs/app/learn-solidity/page.tsx
+++ b/packages/nextjs/app/learn-solidity/page.tsx
@@ -13,7 +13,7 @@ export const metadata = {
   ...getMetadata({
     title: "Learn Solidity with our free Web3 Developer Course",
     description:
-      "Master Solidity with a guided curriculum, real-world challenges, and curated guides. Learn by building on Ethereum.",
+      "Learn Solidity on Speedrun Ethereum: a free, guided curriculum of real-world challenges and developer guides. Learn Ethereum development by building.",
   }),
   alternates: { canonical: "/learn-solidity" },
 };

--- a/packages/nextjs/app/start/page.tsx
+++ b/packages/nextjs/app/start/page.tsx
@@ -53,8 +53,6 @@ const StartLandingPage = async () => {
           height={280}
         />
         <div className="relative z-10 px-6 lg:pb-12">
-          {/* The HeroLogo below is the visual title; this gives crawlers and assistive tech a single,
-              brand-named H1 without altering the playful hero design. */}
           <h1 className="sr-only">Speedrun Ethereum: Learn to Build on Ethereum by Building Real Projects</h1>
           <p className="text-center mb-10 dark:text-gray-200">
             Learn how to build on <strong>Ethereum</strong>; the superpowers and the gotchas.

--- a/packages/nextjs/app/start/page.tsx
+++ b/packages/nextjs/app/start/page.tsx
@@ -24,7 +24,7 @@ import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 export const metadata = getMetadata({
   title: "Build your first Apps on Ethereum",
   description:
-    "Build your first Ethereum apps with hands-on challenges. Learn smart contracts and dapp development through real, practical experience.",
+    "Learn Ethereum development by building real dApps. Speedrun Ethereum is a free, hands-on series of smart contract challenges — from your first NFT to a DEX.",
   path: "/start",
 });
 
@@ -53,6 +53,9 @@ const StartLandingPage = async () => {
           height={280}
         />
         <div className="relative z-10 px-6 lg:pb-12">
+          {/* The HeroLogo below is the visual title; this gives crawlers and assistive tech a single,
+              brand-named H1 without altering the playful hero design. */}
+          <h1 className="sr-only">Speedrun Ethereum: Learn to Build on Ethereum by Building Real Projects</h1>
           <p className="text-center mb-10 dark:text-gray-200">
             Learn how to build on <strong>Ethereum</strong>; the superpowers and the gotchas.
           </p>

--- a/packages/nextjs/guides/automated-market-makers-math.md
+++ b/packages/nextjs/guides/automated-market-makers-math.md
@@ -383,6 +383,6 @@ AMMs revolutionized DeFi by making on-chain trading and liquidity provision simp
 
 ---
 
-**Ready to build or test your own AMM? [Try the Minimum Viable Exchange (Dex) Challenge!](/challenge/dex)**
+**Ready to build or test your own AMM? [Try the Minimum Viable Exchange (Dex) Challenge on Speedrun Ethereum!](/challenge/dex)**
 
 **Want to learn more about LP risks? [Read the Impermanent Loss Guide!](/guides/impermanent-loss-math-explained)**

--- a/packages/nextjs/guides/blockchain-games-vulnerabilities.md
+++ b/packages/nextjs/guides/blockchain-games-vulnerabilities.md
@@ -713,7 +713,7 @@ Building secure blockchain games requires thinking like both a developer and an 
 
 ---
 
-**Ready to build secure games? [Try the Dice Game Challenge!](/challenge/dice-game)**
+**Ready to build secure games? [Try the Dice Game Challenge on Speedrun Ethereum!](/challenge/dice-game)**
 
 **Want to learn more about DeFi security? [Check out the Flash Loan Exploits Guide!](/guides/flash-loan-exploits)**
 

--- a/packages/nextjs/guides/blockchain-randomness-solidity.md
+++ b/packages/nextjs/guides/blockchain-randomness-solidity.md
@@ -284,7 +284,7 @@ Secure randomness is fundamental to fair and trustworthy blockchain applications
 - Always consider economic incentives for manipulation
 - Test thoroughly with adversarial scenarios
 
-**Ready to build provably fair applications?** [Try the Dice Game Challenge!](/challenge/dice-game)
+**Ready to build provably fair applications?** [Try the Dice Game Challenge on Speedrun Ethereum!](/challenge/dice-game)
 
 ---
 

--- a/packages/nextjs/guides/chainlink-vrf-solidity-games.md
+++ b/packages/nextjs/guides/chainlink-vrf-solidity-games.md
@@ -1756,7 +1756,7 @@ Chainlink VRF transforms blockchain gaming by providing cryptographically secure
 
 ---
 
-**Ready to implement VRF in your smart contract? [Try the Dice Game Challenge!](/challenge/dice-game)**
+**Ready to implement VRF in your smart contract? [Try the Dice Game Challenge on Speedrun Ethereum!](/challenge/dice-game)**
 
 **Want to learn more about smart contract security? [Check out the Blockchain Games Security Guide!](/guides/blockchain-games-vulnerabilities)**
 

--- a/packages/nextjs/guides/commit-reveal-scheme.md
+++ b/packages/nextjs/guides/commit-reveal-scheme.md
@@ -699,6 +699,6 @@ The commit-reveal scheme is essential for any blockchain application requiring h
 
 ---
 
-**Ready to build? [Try the Dice Game Challenge!](/challenge/dice-game)**
+**Ready to build? [Try the Dice Game Challenge on Speedrun Ethereum!](/challenge/dice-game)**
 
 **Want to learn more about blockchain security? [Read our Flash Loan Exploits Guide!](/guides/flash-loan-exploits)**

--- a/packages/nextjs/guides/erc20-approve-pattern.md
+++ b/packages/nextjs/guides/erc20-approve-pattern.md
@@ -243,6 +243,6 @@ Staying current with these trends—and adopting new standards and tools as they
 
 ---
 
-**Want to practice? [Try the Token Vendor Challenge!](/challenge/token-vendor)**
+**Want to practice? [Try the Token Vendor Challenge on Speedrun Ethereum!](/challenge/token-vendor)**
 
 **Ready for more? [Build a DEX with the Minimum Viable Exchange (Dex) Challenge!](/challenge/dex)**

--- a/packages/nextjs/guides/erc721-vs-erc1155.md
+++ b/packages/nextjs/guides/erc721-vs-erc1155.md
@@ -248,6 +248,6 @@ There's no one-size-fits-all answer.
 
 ---
 
-**Want to see these standards in action? [Try the Tokenization Challenge!](/challenge/tokenization)**
+**Want to see these standards in action? [Try the Tokenization Challenge on Speedrun Ethereum!](/challenge/tokenization)**
 
 **Already comfortable with the basics? [Try the SVG NFT Challenge!](/challenge/svg-nft)**

--- a/packages/nextjs/guides/flash-loan-exploits.md
+++ b/packages/nextjs/guides/flash-loan-exploits.md
@@ -494,6 +494,6 @@ By implementing these defensive patterns, you're not just protecting your protoc
 
 ---
 
-**Ready to build secure DeFi? [Try the Minimum Viable Exchange (Dex) Challenge!](/challenge/dex)**
+**Ready to build secure DeFi? [Try the Minimum Viable Exchange (Dex) Challenge on Speedrun Ethereum!](/challenge/dex)**
 
 **Want to learn more about token security? [Check out the ERC20 Approve Pattern Guide!](/guides/erc20-approve-pattern)**

--- a/packages/nextjs/guides/front-running-mev-mitigation.md
+++ b/packages/nextjs/guides/front-running-mev-mitigation.md
@@ -197,4 +197,4 @@ MEV is a fact of life in DeFi, but you can fight back. As a builder, enforce sli
 
 ---
 
-**Ready to build a secure DEX? [Try the Minimum Viable Exchange (Dex) Challenge!](/challenge/dex)**
+**Ready to build a secure DEX? [Try the Minimum Viable Exchange (Dex) Challenge on Speedrun Ethereum!](/challenge/dex)**

--- a/packages/nextjs/guides/impermanent-loss-math-explained.md
+++ b/packages/nextjs/guides/impermanent-loss-math-explained.md
@@ -391,6 +391,6 @@ Impermanent loss doesn't have to be a barrier to DeFi participation, it's a risk
 
 ---
 
-**Ready to practice? [Try the Minimum Viable Exchange (Dex) Challenge!](/challenge/dex)**
+**Ready to practice? [Try the Minimum Viable Exchange (Dex) Challenge on Speedrun Ethereum!](/challenge/dex)**
 
 **Want to build with tokens? [Try the Token Vendor Challenge!](/challenge/token-vendor)**

--- a/packages/nextjs/guides/mastering-erc721.md
+++ b/packages/nextjs/guides/mastering-erc721.md
@@ -139,6 +139,6 @@ Mastering ERC721, metadata, and URI management is fundamental for creating valua
 
 ---
 
-**Ready to build your first NFT? [Try the Tokenization Challenge!](/challenge/tokenization)**
+**Ready to build your first NFT? [Try the Tokenization Challenge on Speedrun Ethereum!](/challenge/tokenization)**
 
 **Already comfortable with the basics? [Try the SVG NFT Challenge!](/challenge/svg-nft)**

--- a/packages/nextjs/guides/nft-use-cases.md
+++ b/packages/nextjs/guides/nft-use-cases.md
@@ -131,6 +131,6 @@ NFTs are a cornerstone of the decentralized web, enabling:
 
 ---
 
-**Ready to build your first NFT? [Try the Tokenization Challenge!](/challenge/tokenization)**
+**Ready to build your first NFT? [Try the Tokenization Challenge on Speedrun Ethereum!](/challenge/tokenization)**
 
 **Already comfortable with the basics? [Try the SVG NFT Build Idea!](/build-prompts)**

--- a/packages/nextjs/guides/solidity-contract-to-contract-interactions.md
+++ b/packages/nextjs/guides/solidity-contract-to-contract-interactions.md
@@ -284,4 +284,4 @@ Mastering contract-to-contract interactions is essential for any Solidity develo
 
 ---
 
-**Ready to put these patterns into practice? [Try the Token Vendor Challenge!](/challenge/token-vendor)**
+**Ready to put these patterns into practice? [Try the Token Vendor Challenge on Speedrun Ethereum!](/challenge/token-vendor)**

--- a/packages/nextjs/guides/solidity-nft-security.md
+++ b/packages/nextjs/guides/solidity-nft-security.md
@@ -167,6 +167,6 @@ Securing your NFT smart contracts is not a one-time task but an ongoing commitme
 
 ---
 
-**Want to put these security best practices to the test in your own NFT project? [Try the Tokenization Challenge!](/challenge/tokenization)**
+**Want to put these security best practices to the test in your own NFT project? [Try the Tokenization Challenge on Speedrun Ethereum!](/challenge/tokenization)**
 
 **Already comfortable with the basics? [Try the SVG NFT Build Idea!](/build-prompts)**

--- a/packages/nextjs/utils/challenges.ts
+++ b/packages/nextjs/utils/challenges.ts
@@ -34,7 +34,7 @@ export const CHALLENGE_METADATA: Record<string, ChallengeStaticMetadata> = {
   [ChallengeId.TOKENIZATION]: {
     title: "Learn How to Create an NFT in Solidity",
     description:
-      "Build your first NFT smart contract in Solidity. Step-by-step tutorial to mint and deploy NFTs on Ethereum using Scaffold-ETH.",
+      "Build and deploy your first NFT smart contract in Solidity. A free, hands-on Speedrun Ethereum challenge — mint NFTs on Ethereum with Scaffold-ETH 2.",
     isAiReady: true,
     skills: [
       "Compile and deploy your first **smart contract**",
@@ -70,7 +70,7 @@ export const CHALLENGE_METADATA: Record<string, ChallengeStaticMetadata> = {
   [ChallengeId.CROWDFUNDING]: {
     title: "Build a Crowdfunding Application in Solidity",
     description:
-      "Learn to build a crowdfunding application with Solidity. Step-by-step tutorial to help adversarial parties work together to fund a project using Solidity smart contracts on Ethereum.",
+      "Build a decentralized crowdfunding dApp in Solidity with a state machine, payable functions, and events. A free, hands-on Speedrun Ethereum challenge.",
     isAiReady: true,
     skills: [
       "Design and implement a decentralized application (dApp) with a state machine",
@@ -100,7 +100,7 @@ export const CHALLENGE_METADATA: Record<string, ChallengeStaticMetadata> = {
   [ChallengeId.TOKEN_VENDOR]: {
     title: "Create an ERC20 Token and Vendor Contract in Solidity",
     description:
-      "Learn to create your own ERC20 token and build a decentralized vending machine using Solidity smart contracts on Ethereum.",
+      "Create your own ERC20 token and build a decentralized token vending machine in Solidity. A free, hands-on challenge from Speedrun Ethereum.",
     isAiReady: true,
     skills: [
       "Build a custom token on the **ERC20** standard",
@@ -146,7 +146,7 @@ export const CHALLENGE_METADATA: Record<string, ChallengeStaticMetadata> = {
   [ChallengeId.DICE_GAME]: {
     title: "Exploit a Vulnerable Dice Game in Solidity",
     description:
-      "Learn blockchain security by building an attack contract that exploits randomness vulnerabilities in a Solidity dice game. Hands-on security tutorial for developers.",
+      "Learn smart contract security by exploiting a vulnerable Solidity dice game, then understand the fix. A free, hands-on Speedrun Ethereum challenge on on-chain randomness.",
     isAiReady: true,
     skills: [
       "Understand why randomness is tricky on the blockchain",
@@ -178,7 +178,7 @@ export const CHALLENGE_METADATA: Record<string, ChallengeStaticMetadata> = {
   [ChallengeId.DEX]: {
     title: "How to Build a Decentralized Exchange (DEX) in Solidity",
     description:
-      "Step-by-step tutorial to build your own DEX with liquidity pools, token swapping, and automated market making in Solidity.",
+      "Build your own DEX in Solidity with liquidity pools, token swaps, and an automated market maker (AMM). A free, hands-on challenge from Speedrun Ethereum.",
     isAiReady: true,
     skills: [
       "Build and understand an **Automated Market Maker (AMM)**",
@@ -216,7 +216,7 @@ export const CHALLENGE_METADATA: Record<string, ChallengeStaticMetadata> = {
   [ChallengeId.ORACLES]: {
     title: "Build Decentralized Oracle Systems in Solidity",
     description:
-      "Learn to build three fundamental oracle architectures: Whitelist, Staking, and Optimistic Oracles. Understand trade-offs between security, decentralization, and efficiency while implementing dispute resolution and economic incentive mechanisms.",
+      "Build three oracle architectures in Solidity — whitelist, staking, and optimistic — with dispute resolution and economic incentives. A free Speedrun Ethereum challenge.",
     isAiReady: true,
     skills: [
       "Deeply understand how different oracle architectures work and their trade-offs",
@@ -234,7 +234,7 @@ export const CHALLENGE_METADATA: Record<string, ChallengeStaticMetadata> = {
   [ChallengeId.OVER_COLLATERALIZED_LENDING]: {
     title: "Build an Over-Collateralized Lending Platform in Solidity",
     description:
-      "Learn how to create an over-collateralized lending platform using Solidity smart contracts on Ethereum.",
+      "Build an over-collateralized lending and borrowing protocol in Solidity, with liquidations and flash loans. A free, hands-on Speedrun Ethereum challenge.",
     isAiReady: true,
     skills: [
       "Understand how over-collateralized lending works",
@@ -252,7 +252,7 @@ export const CHALLENGE_METADATA: Record<string, ChallengeStaticMetadata> = {
   [ChallengeId.STABLECOINS]: {
     title: "Build a Stablecoin in Solidity",
     description:
-      "Learn how to create a stablecoin using Solidity smart contracts on Ethereum. Understand stability mechanisms and price oracles.",
+      "Build an algorithmic stablecoin in Solidity — collateralization, liquidations, and peg incentives. A free, hands-on challenge from Speedrun Ethereum.",
     isAiReady: true,
     skills: [
       "Understand how collateralization levels and liquidations work together in an **algorithmic stablecoin** system",
@@ -276,7 +276,7 @@ export const CHALLENGE_METADATA: Record<string, ChallengeStaticMetadata> = {
   [ChallengeId.PREDICTION_MARKETS]: {
     title: "Create a Prediction Market in Solidity",
     description:
-      "Learn to build decentralized prediction markets using Solidity. Understand market creation, betting mechanics, and outcome resolution.",
+      "Build a decentralized prediction market in Solidity — market creation, betting mechanics, and oracle-based outcome resolution. A free Speedrun Ethereum challenge.",
     isAiReady: true,
     skills: [
       "Design and build a complete onchain **prediction market** from creation to settlement",
@@ -297,7 +297,7 @@ export const CHALLENGE_METADATA: Record<string, ChallengeStaticMetadata> = {
   [ChallengeId.ZK_VOTING]: {
     title: "Build a Privacy-Preserving ZK Voting dApp",
     description:
-      "Learn how to build a privacy-preserving ZK voting dApp where members vote anonymously using zero-knowledge proofs, Merkle trees, and nullifier hashes to prevent double voting.",
+      "Build a privacy-preserving ZK voting dApp in Solidity and Noir, using zero-knowledge proofs, Merkle trees, and nullifiers. A free, hands-on Speedrun Ethereum challenge.",
     isAiReady: true,
     skills: [
       "Design a **commitment + nullifier** scheme to enforce one-person-one-vote",


### PR DESCRIPTION
Names Speedrun Ethereum as the source across metadata and existing on-page copy, so AI assistants that already surface these pages credit the brand.

## Why
In AI-visibility testing, LLMs (Claude) already cite Speedrun Ethereum pages when answering "how to learn / how to build X on Ethereum" questions - but often name other resources as the answer, because the pages don't clearly identify Speedrun Ethereum as the source. This adds the brand where it's currently missing, with no layout or design changes.

## What changed
- **Challenge meta descriptions** (`utils/challenges.ts`): each now names Speedrun Ethereum and leads with the build + "free / hands-on" framing (head metadata only; no visible page change).
- **Guide closing CTAs** (14 guides): the existing "Try the X Challenge!" link now reads "…on Speedrun Ethereum" (one mention each, riding the existing convention).
- **Landing pages**: `/start` gains a semantic H1 (it had none; the logo is unchanged), and the `/learn-solidity` hero subcopy and `/build-prompts` intro name the brand.

No new UI elements, no keyword-changing H1 edits, no logic changes.

## Companion PRs
These complement the challenge-body changes in `scaffold-eth/se-2-challenges` (challenge READMEs render on the challenge pages):
- Prediction Markets challenge intro: https://github.com/scaffold-eth/se-2-challenges/pull/493
- DEX challenge intro: https://github.com/scaffold-eth/se-2-challenges/pull/494
