### PR TITLE
Self-identify guides with breadcrumb and TechArticle structured data

### DIFF
--- a/packages/nextjs/app/guides/[slug]/page.tsx
+++ b/packages/nextjs/app/guides/[slug]/page.tsx
@@ -1,7 +1,9 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { GuideSidebar } from "../_components/GuideSidebar";
 import { formatGuideDate, getAllGuidesSlugs, getGuideBySlug } from "~~/services/guides";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
+import { getGuideStructuredData } from "~~/utils/structuredData";
 
 export async function generateStaticParams() {
   const slugs = await getAllGuidesSlugs();
@@ -46,6 +48,15 @@ export default async function GuidePage(props: { params: Promise<{ slug: string 
       }
     : null;
 
+  const guideSchema = getGuideStructuredData({
+    slug: params.slug,
+    title: guide.title,
+    description: guide.description,
+    image: guide.image,
+    datePublished: guide.date,
+  });
+  const structuredData = faqSchema ? [...guideSchema, faqSchema] : guideSchema;
+
   const showNavigation = guide.showNavigation && guide.headings.length > 0;
 
   // When navigation is shown, the hero and the article share a single 2-column grid (TOC + content)
@@ -55,6 +66,17 @@ export default async function GuidePage(props: { params: Promise<{ slug: string 
 
   const heroHeader = (
     <>
+      <nav aria-label="Breadcrumb" className="text-sm text-base-content/80 mb-3">
+        <Link href="/" className="hover:underline">
+          Speedrun Ethereum
+        </Link>
+        <span className="mx-1.5" aria-hidden>
+          ›
+        </span>
+        <Link href="/guides" className="hover:underline">
+          Guides
+        </Link>
+      </nav>
       <h1 className="text-3xl lg:text-4xl font-extrabold text-base-content mb-3">{guide.title}</h1>
       {guide.description && <p className="text-lg text-base-content/90 mb-4">{guide.description}</p>}
       <div className="text-sm text-base-content/80 flex items-center gap-4 flex-wrap">
@@ -86,9 +108,7 @@ export default async function GuidePage(props: { params: Promise<{ slug: string 
 
   return (
     <>
-      {faqSchema && (
-        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
-      )}
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
 
       <div className="bg-[#A8E7F4] dark:bg-[#015555] py-10 lg:py-14">
         <div className={`${containerClass} ${gridClass}`}>

--- a/packages/nextjs/app/guides/page.tsx
+++ b/packages/nextjs/app/guides/page.tsx
@@ -1,26 +1,46 @@
+import Link from "next/link";
 import SearchGuides from "./_components/SearchGuides";
 import { getAllGuides } from "~~/services/guides";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
+import { getGuidesIndexStructuredData } from "~~/utils/structuredData";
+
+// Shared with the structured data below so the two never drift.
+const title = "Solidity Tutorials and Guides";
+const description =
+  "Discover in-depth Solidity tutorials and guides to help you become a blockchain developer. Learn Solidity programming, smart contract development, and best practices for building on Ethereum.";
 
 export const metadata = getMetadata({
-  title: "Solidity Tutorials and Guides",
-  description:
-    "Discover in-depth Solidity tutorials and guides to help you become a blockchain developer. Learn Solidity programming, smart contract development, and best practices for building on Ethereum.",
+  title,
+  description,
   path: "/guides",
 });
 
 export default async function GuidesPage() {
   const guides = await getAllGuides();
+  const structuredData = getGuidesIndexStructuredData({ title, description });
 
   return (
-    <div className="container mx-auto px-2 py-10 max-w-7xl">
-      <h1 className="text-4xl font-bold mb-8 text-center">Solidity Tutorials and Guides</h1>
-      <p className="mb-8 text-center text-base-content/80 max-w-2xl mx-auto">
-        Start your journey with our comprehensive Solidity tutorials and guides. Whether you&apos;re new to blockchain
-        development or looking to advance your smart contract skills, these resources will help you learn Solidity
-        programming, understand Ethereum, and build secure decentralized applications.
-      </p>
-      <SearchGuides guides={guides} />
-    </div>
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+
+      <div className="container mx-auto px-2 py-10 max-w-7xl">
+        <nav aria-label="Breadcrumb" className="text-sm text-base-content/80 mb-3 text-center">
+          <Link href="/" className="hover:underline">
+            Speedrun Ethereum
+          </Link>
+          <span className="mx-1.5" aria-hidden>
+            ›
+          </span>
+          <span>Guides</span>
+        </nav>
+        <h1 className="text-4xl font-bold mb-8 text-center">Solidity Tutorials and Guides</h1>
+        <p className="mb-8 text-center text-base-content/80 max-w-2xl mx-auto">
+          Start your journey with our comprehensive Solidity tutorials and guides. Whether you&apos;re new to blockchain
+          development or looking to advance your smart contract skills, these resources will help you learn Solidity
+          programming, understand Ethereum, and build secure decentralized applications.
+        </p>
+        <SearchGuides guides={guides} />
+      </div>
+    </>
   );
 }

--- a/packages/nextjs/utils/structuredData.ts
+++ b/packages/nextjs/utils/structuredData.ts
@@ -46,6 +46,54 @@ export function getHomepageStructuredData(challenges: Challenges, description: s
   return [course, itemList];
 }
 
+// Guide page: a TechArticle tied back to the curriculum, plus its breadcrumb trail.
+export function getGuideStructuredData({
+  slug,
+  title,
+  description,
+  image,
+  datePublished,
+}: {
+  slug: string;
+  title: string;
+  description: string;
+  image?: string;
+  datePublished?: string;
+}) {
+  const url = `${SITE_URL}/guides/${slug}`;
+
+  const article = {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: title,
+    description,
+    url,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": url,
+    },
+    ...(image ? { image: `${SITE_URL}${image}` } : {}),
+    ...(datePublished ? { datePublished } : {}),
+    author: provider,
+    publisher: provider,
+    isPartOf: {
+      "@id": COURSE_ID,
+    },
+  };
+
+  const breadcrumb = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: COURSE_NAME, item: SITE_URL },
+      { "@type": "ListItem", position: 2, name: "Guides", item: `${SITE_URL}/guides` },
+      { "@type": "ListItem", position: 3, name: title, item: url },
+    ],
+  };
+
+  return [article, breadcrumb];
+}
+
 // Challenge page: a Course node for a single challenge, tied back to the curriculum.
 export function getChallengeStructuredData({
   id,

--- a/packages/nextjs/utils/structuredData.ts
+++ b/packages/nextjs/utils/structuredData.ts
@@ -94,6 +94,38 @@ export function getGuideStructuredData({
   return [article, breadcrumb];
 }
 
+// Guides index: a CollectionPage tied back to the curriculum, plus its breadcrumb trail.
+export function getGuidesIndexStructuredData({ title, description }: { title: string; description: string }) {
+  const url = `${SITE_URL}/guides`;
+
+  const collection = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: title,
+    description,
+    url,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": url,
+    },
+    publisher: provider,
+    isPartOf: {
+      "@id": COURSE_ID,
+    },
+  };
+
+  const breadcrumb = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: COURSE_NAME, item: SITE_URL },
+      { "@type": "ListItem", position: 2, name: "Guides", item: url },
+    ],
+  };
+
+  return [collection, breadcrumb];
+}
+
 // Challenge page: a Course node for a single challenge, tied back to the curriculum.
 export function getChallengeStructuredData({
   id,


### PR DESCRIPTION
## Summary

Follow-up to #398, extending the same structured data approach to the guides.

- **Guides do not name Speedrun Ethereum anywhere in the page content.** The header logo is client-rendered, so crawlers that skip JavaScript never see the brand on guide pages. Added a small "Speedrun Ethereum › Guides" breadcrumb above the guide h1. Both segments are working links (home and the guides index).
- **Guides emit no page-level structured data**, only FAQ schema when the frontmatter has `faqs`. Added `getGuideStructuredData()` in `utils/structuredData.ts`: a `TechArticle` node (headline, description, image, datePublished, `mainEntityOfPage`, publisher BuidlGuidl, and `isPartOf` pointing at the shared `#course` entity from #398) plus a `BreadcrumbList` matching the visible breadcrumb. Merged with the existing FAQ schema into a single JSON-LD script.

Canonicals were already handled in #399, so no changes there. No layout changes beyond the one breadcrumb line.

## How to test

1. `cd packages/nextjs && yarn dev`
2. Open any guide, e.g. `/guides/how-to-create-erc20`: a "Speedrun Ethereum › Guides" breadcrumb renders above the title and both links resolve.
3. View source: one `ld+json` script containing `TechArticle` and `BreadcrumbList` (plus `FAQPage` on `/guides/how-to-build-dapp-ethereum-ai-workflow`, the one guide with `faqs`).
4. `yarn check-types` passes.