### PR TITLE
Guides: on-page navigation, date-based sorting, and reading time

### DIFF
--- a/packages/nextjs/app/guides/[slug]/page.tsx
+++ b/packages/nextjs/app/guides/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { GuideSidebar } from "../_components/GuideSidebar";
-import { formatGuideDate, getAllGuidesSlugs, getGuideBySlug } from "~~/services/guides";
+import { getAllGuidesSlugs, getGuideBySlug } from "~~/services/guides";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
 export async function generateStaticParams() {
@@ -57,7 +57,6 @@ export default async function GuidePage(props: { params: Promise<{ slug: string 
       <h1 className="text-3xl lg:text-4xl font-extrabold text-base-content mb-3">{guide.title}</h1>
       {guide.description && <p className="text-lg text-base-content/90 mb-4">{guide.description}</p>}
       <div className="text-sm text-base-content/80 flex items-center gap-4 flex-wrap">
-        {guide.date && <span>📅 {formatGuideDate(guide.date)}</span>}
         <span>🕐 {guide.readingTime} min read</span>
       </div>
     </>

--- a/packages/nextjs/app/guides/_components/GuideSidebar.tsx
+++ b/packages/nextjs/app/guides/_components/GuideSidebar.tsx
@@ -48,7 +48,7 @@ export function GuideSidebar({ headings }: GuideSidebarProps) {
 
   return (
     <aside className="hidden lg:block">
-      <nav className="lg:sticky lg:top-8 max-h-[calc(100vh-4rem)] overflow-y-auto pr-2">
+      <nav className="toc-scrollbar lg:sticky lg:top-8 max-h-[calc(100vh-4rem)] overflow-y-auto pr-2">
         <h2 className="font-semibold text-xs uppercase tracking-wider text-base-content/50 mb-3">On this page</h2>
         <ul className="border-l border-base-300">
           {headings.map(heading => (

--- a/packages/nextjs/app/guides/_components/SearchGuides.tsx
+++ b/packages/nextjs/app/guides/_components/SearchGuides.tsx
@@ -67,7 +67,8 @@ export default function SearchGuides({ guides }: { guides: Guide[] }) {
                   <p className="mt-4 text-base-content/80 line-clamp-3">{guide.description}</p>
                 </div>
 
-                <div className="flex justify-end mt-4">
+                <div className="flex items-center justify-between mt-4">
+                  <span className="text-sm text-base-content/70">🕐 {guide.readingTime} min read</span>
                   <Link href={`/guides/${guide.slug}`} className="btn btn-primary btn-sm">
                     Read more
                   </Link>

--- a/packages/nextjs/guides/automated-market-makers-math.md
+++ b/packages/nextjs/guides/automated-market-makers-math.md
@@ -1,7 +1,9 @@
 ---
 title: "Automated Market Makers (AMMs): Math, Risks & Solidity Code"
+date: "2025-07-10"
 description: "How AMMs like Uniswap work: constant product formula (x*y=k), price impact, impermanent loss, and Solidity code. Essential for DeFi traders, LPs, and smart contract devs."
 image: "/assets/guides/automated-market-makers-math.jpg"
+showNavigation: true
 ---
 
 ## TL;DR: Automated Market Makers (AMMs) in DeFi

--- a/packages/nextjs/guides/blockchain-games-vulnerabilities.md
+++ b/packages/nextjs/guides/blockchain-games-vulnerabilities.md
@@ -1,7 +1,9 @@
 ---
 title: "Blockchain Game Security: Vulnerability Defense Tutorial"
+date: "2025-09-01"
 description: "Master blockchain game security with this comprehensive tutorial to smart contract vulnerabilities, randomness exploits, and defense patterns. Includes Solidity examples and real-world attack scenarios for Web3 developers."
 image: "/assets/guides/blockchain-games-security.jpg"
+showNavigation: true
 ---
 
 ## TL;DR: Blockchain Game Security Essentials

--- a/packages/nextjs/guides/blockchain-randomness-solidity.md
+++ b/packages/nextjs/guides/blockchain-randomness-solidity.md
@@ -1,7 +1,9 @@
 ---
 title: "Secure Randomness in Solidity: Beyond Block Variables"
+date: "2025-08-28"
 description: "Learn why block.timestamp and blockhash fail for randomness in Solidity. Master Chainlink VRF and commit-reveal schemes to build provably fair smart contracts and secure blockchain games."
 image: "/assets/guides/blockchain-randomness-solidity.jpg"
+showNavigation: true
 ---
 
 ## TL;DR: Blockchain Randomness in Solidity

--- a/packages/nextjs/guides/chainlink-vrf-solidity-games.md
+++ b/packages/nextjs/guides/chainlink-vrf-solidity-games.md
@@ -1,7 +1,9 @@
 ---
 title: "Chainlink VRF Implementation: Provably Fair Randomness for Smart Contracts"
+date: "2025-08-25"
 description: "Learn to implement Chainlink VRF v2 in Solidity smart contracts for provably fair randomness. Complete guide with code examples, security patterns, and best practices for Web3 developers."
 image: "/assets/guides/chainlink-vrf-in-smart-contracts.jpg"
+showNavigation: true
 ---
 
 ## TL;DR: Chainlink VRF for Solidity Smart Contracts

--- a/packages/nextjs/guides/commit-reveal-scheme.md
+++ b/packages/nextjs/guides/commit-reveal-scheme.md
@@ -1,7 +1,9 @@
 ---
 title: "Commit-Reveal Scheme in Solidity"
+date: "2025-08-21"
 description: "Learn how to implement the commit-reveal scheme in Solidity to prevent front-running attacks in blockchain games. Complete guide with code examples, security best practices, and real-world applications."
 image: "/assets/guides/commit-reveal-scheme-solidity.jpg"
+showNavigation: true
 ---
 
 ## TL;DR: Commit-Reveal Scheme in Solidity

--- a/packages/nextjs/guides/erc-4626-vaults.md
+++ b/packages/nextjs/guides/erc-4626-vaults.md
@@ -1,7 +1,9 @@
 ---
 title: "ERC4626 Vaults: Secure Design, Risks & Best Practices"
+date: "2025-09-19"
 description: "Developer guide to ERC4626 vaults: core functions, key risks (inflation, reentrancy, oracle), and secure fees, caps, queues with Solidity examples."
 image: "/assets/guides/erc4626-vaults.jpg"
+showNavigation: true
 ---
 
 ## TL;DR:
@@ -276,7 +278,7 @@ function _accrueFees(uint256 realizedGainAssets) internal {
 
 ---
 
-## 8) Related Guides & Next Steps
+## 8. Related Guides & Next Steps
 
 - Learn secure token approvals: [ERC20 Approve Pattern](/guides/erc20-approve-pattern)
 - Master cross-contract calls: [Solidity Contract-to-Contract Interactions](/guides/solidity-contract-to-contract-interactions)

--- a/packages/nextjs/guides/erc20-approve-pattern.md
+++ b/packages/nextjs/guides/erc20-approve-pattern.md
@@ -1,7 +1,9 @@
 ---
 title: "ERC20 Approve Pattern: Secure Token Allowances Guide"
+date: "2025-06-10"
 description: "A concise, developer-focused guide to the ERC20 approve pattern. Learn how token allowances work, common pitfalls, and best practices for secure dApp development and user safety. Includes Solidity examples and actionable tips."
 image: "/assets/guides/approve-pattern.jpg"
+showNavigation: true
 ---
 
 ## TL;DR: ERC20 Approve Pattern

--- a/packages/nextjs/guides/erc721-vs-erc1155.md
+++ b/packages/nextjs/guides/erc721-vs-erc1155.md
@@ -1,7 +1,9 @@
 ---
 title: "ERC721 vs. ERC1155: Key Differences, Use Cases & How to Choose"
+date: "2025-05-09"
 description: "A comparison guide for choosing between ERC721 and ERC1155 NFT standards. Understand the key differences, use cases, and decision factors to select the best standard for your project."
 image: /assets/guides/erc1155vs721.jpg
+showNavigation: true
 ---
 
 ## TL;DR: ERC721 vs ERC1155

--- a/packages/nextjs/guides/flash-loan-exploits.md
+++ b/packages/nextjs/guides/flash-loan-exploits.md
@@ -1,7 +1,9 @@
 ---
 title: "Flash Loan Exploits: A Developer's Guide to Securing Your DEX"
+date: "2025-07-06"
 description: "Dive into real-world flash loan exploits like PancakeBunny & Cream Finance. Learn defensive Solidity patterns like TWAP oracles and reentrancy guards to prevent DEX hacks."
 image: /assets/guides/flash-loan-exploits.jpg
+showNavigation: true
 ---
 
 ## TL;DR: Flash Loan Exploits & DEX Security
@@ -29,6 +31,8 @@ This mechanism enables legitimate use cases like arbitrage, collateral swaps, an
 For developers building DEXs and DeFi protocols, understanding flash loan attack vectors is essential. This guide will show you how to build resilient systems that can withstand these sophisticated attacks.
 
 ---
+
+## 2. The Anatomy of a Flash Loan Attack
 
 Every flash loan attack follows a universal pattern:
 

--- a/packages/nextjs/guides/front-running-mev-mitigation.md
+++ b/packages/nextjs/guides/front-running-mev-mitigation.md
@@ -1,7 +1,9 @@
 ---
 title: "Front-Running & MEV Mitigation: A DEX Developer's Guide"
+date: "2025-07-03"
 description: "Learn to mitigate front-running and MEV attacks on your DEX. This guide covers key strategies, Solidity examples, and a checklist for developers."
 image: "/assets/guides/front-running-mev-mitigation.jpg"
+showNavigation: true
 ---
 
 ## TL;DR: Front-Running & MEV in DeFi

--- a/packages/nextjs/guides/how-to-create-erc20.md
+++ b/packages/nextjs/guides/how-to-create-erc20.md
@@ -1,7 +1,9 @@
 ---
 title: "How to Create an ERC20 Token: Complete Solidity Tutorial"
+date: "2025-06-06"
 description: "Step-by-step guide to creating your own ERC20 token in Solidity. Learn the standard, write the contract, and deploy to Ethereum. Includes code, security tips, and best practices."
 image: "/assets/guides/create-erc20-token.jpg"
+showNavigation: true
 ---
 
 Want to launch your own digital currency or utility token on the Ethereum blockchain? This guide provides a comprehensive walkthrough on **how to create an ERC20 token using Solidity**. An ERC20 token is the most widely adopted standard for fungible (interchangeable) tokens on Ethereum, making them essential building blocks for countless decentralized applications (dApps).

--- a/packages/nextjs/guides/impermanent-loss-math-explained.md
+++ b/packages/nextjs/guides/impermanent-loss-math-explained.md
@@ -1,7 +1,9 @@
 ---
 title: "Impermanent Loss Explained: The Math Behind DeFi's Hidden Risk"
+date: "2025-06-29"
 description: "Learn everything about impermanent loss in DeFi. Understand the formula, see real-world examples, and discover key strategies to protect your crypto assets as a liquidity provider."
 image: "/assets/guides/impermanent-loss-math-explained.jpg"
+showNavigation: true
 ---
 
 Understanding impermanent loss is crucial for anyone participating in decentralized finance (DeFi). This often-misunderstood risk can turn a profitable-looking venture into a net loss for a liquidity provider. In this guide, we break down the exact impermanent loss formula, show you how to calculate it, and provide actionable strategies to minimize its impact.

--- a/packages/nextjs/guides/liquid-staking-tokens.md
+++ b/packages/nextjs/guides/liquid-staking-tokens.md
@@ -1,7 +1,9 @@
 ---
 title: "A Developer's Guide to Liquid Staking Tokens (LSTs)"
+date: "2025-05-23"
 description: "Staked your ETH but miss using its value in DeFi? Discover Liquid Staking Tokens (LSTs)! This guide explains how LSTs like stETH and rETH work, the difference between rebasing and reward-bearing tokens, and their impact on DeFi. Essential for Solidity devs exploring advanced staking."
 image: /assets/guides/liquid-staking-tokens.jpg
+showNavigation: true
 ---
 
 So, you've learned about staking, maybe even built a basic staking contract. You lock up your ETH (or other PoS assets) to help secure the network and earn rewards. Awesome! But there's a catch: while your crypto is staked, it's usually stuck – illiquid and unusable for anything else. What if you could earn those staking rewards _and_ still use the value of your staked assets in DeFi?

--- a/packages/nextjs/guides/mastering-erc721.md
+++ b/packages/nextjs/guides/mastering-erc721.md
@@ -1,7 +1,9 @@
 ---
 title: "Mastering ERC721: Developer Guide to NFT Metadata & Best Practices"
+date: "2025-05-06"
 description: "A comprehensive technical guide for developers on the ERC721 NFT standard: metadata, tokenURI management, OpenZeppelin usage, and best practices for building robust, marketplace-ready NFTs."
 image: /assets/guides/mastering-erc721.jpg
+showNavigation: true
 ---
 
 NFTs (Non-Fungible Tokens) have revolutionized digital ownership, but building robust, marketplace-ready NFTs requires more than just a simple mint function. **This guide will help you master ERC721 as a developer**—from the basics to advanced metadata management, tokenURI best practices, and real-world deployment tips.

--- a/packages/nextjs/guides/nft-use-cases.md
+++ b/packages/nextjs/guides/nft-use-cases.md
@@ -1,7 +1,9 @@
 ---
 title: "NFTs in Web3: Understanding Use Cases Beyond Digital Art"
+date: "2025-05-02"
 description: "Explore the real-world applications of NFTs in Web3, from gaming and virtual real estate to ticketing, IP protection, and loyalty programs. See how NFTs are transforming industries beyond art."
 image: /assets/guides/nfts_in_web3.jpg
+showNavigation: true
 ---
 
 NFTs (Non-Fungible Tokens) are often associated with digital art and collectibles, but their potential in the Web3 ecosystem goes far beyond profile pictures and rare images. As unique, verifiable digital assets on the blockchain, NFTs are revolutionizing industries and enabling new forms of ownership, interaction, and value exchange.

--- a/packages/nextjs/guides/register-ens-domain-set-avatar.md
+++ b/packages/nextjs/guides/register-ens-domain-set-avatar.md
@@ -1,7 +1,9 @@
 ---
 title: "How to Register an ENS Address and Set Your ENS Avatar"
+date: "2025-09-15"
 description: "Step-by-step guide to register an ENS address (.eth), secure your Web3 identity, and set an ENS avatar. Covers pricing, commit–reveal, reverse resolution, and best practices."
 image: "/assets/guides/how-to-register-ens-set-avatar.jpg"
+showNavigation: true
 ---
 
 ## TL;DR:

--- a/packages/nextjs/guides/scalable-gas-solidity-staking.md
+++ b/packages/nextjs/guides/scalable-gas-solidity-staking.md
@@ -1,7 +1,9 @@
 ---
 title: "Scalable Solidity Staking: O(1) Reward Distribution"
+date: "2025-05-20"
 description: "Master scalable Solidity staking with O(1) reward distribution. This guide details gas-efficient techniques using per-token accumulated values for fair, low-cost DeFi rewards, perfect for optimizing your smart contracts."
 image: /assets/guides/scalable-staking-rewards-solidity.jpg
+showNavigation: true
 ---
 
 So, you're building a decentralized staking contract and you want users to be able to stake their tokens and earn rewards. Simple, right?

--- a/packages/nextjs/guides/solidity-bonding-curves-token-pricing.md
+++ b/packages/nextjs/guides/solidity-bonding-curves-token-pricing.md
@@ -1,7 +1,9 @@
 ---
 title: "Solidity Bonding Curves & Dynamic Token Pricing Explained"
+date: "2025-06-03"
 description: "A developer-focused guide to bonding curves and dynamic token pricing in Solidity. Learn the math, use cases, and best practices for implementing bonding curves in your dApps. Includes Solidity code and real-world examples."
 image: "/assets/guides/bonding-curves.jpg"
+showNavigation: true
 ---
 
 ## TL;DR
@@ -276,7 +278,7 @@ contract LinearBondingCurve {
 - **Gas costs** for complex math on Layer 1
 - **Latecomer disadvantage** (prices can get very high)
 
-## Additional Security Risks
+### Additional Security Risks
 
 - **Price manipulation:** Large actors can move the price significantly by executing big trades, creating misleading market signals.
 - **Oracle risks:** If using oracles, manipulation or failure can impact pricing.

--- a/packages/nextjs/guides/solidity-contract-to-contract-interactions.md
+++ b/packages/nextjs/guides/solidity-contract-to-contract-interactions.md
@@ -1,7 +1,9 @@
 ---
 title: "Solidity Contract-to-Contract Interactions Guide"
+date: "2025-05-30"
 description: "A practical guide to Solidity contract-to-contract interactions. Learn how contracts call each other, handle errors, and manage security. Includes code patterns, pitfalls, and best practices."
 image: "/assets/guides/contract-interactions.jpg"
+showNavigation: true
 ---
 
 ## TL;DR: Secure Contract-to-Contract Interactions in Solidity

--- a/packages/nextjs/guides/solidity-nft-security.md
+++ b/packages/nextjs/guides/solidity-nft-security.md
@@ -1,7 +1,9 @@
 ---
 title: "Solidity NFT Security: 10 Best Practices to Protect Your Collectibles"
+date: "2025-04-29"
 description: "Discover the top security best practices for NFT smart contracts in Solidity. Learn how to avoid common vulnerabilities, use OpenZeppelin, and audit your ERC721 contracts for real-world deployment."
 image: /assets/guides/solidity-nft-security.jpg
+showNavigation: true
 ---
 
 Non-Fungible Tokens (NFTs) have exploded in popularity, representing billions of dollars in digital assets. However, with great value comes great risk. Smart contract vulnerabilities can lead to devastating losses for both creators and collectors. If you're developing NFT projects using Solidity, prioritizing security isn't just advisable—it's essential.

--- a/packages/nextjs/guides/sustainable-erc20-supply-models.md
+++ b/packages/nextjs/guides/sustainable-erc20-supply-models.md
@@ -1,7 +1,9 @@
 ---
 title: "Sustainable ERC20 Supply Models: Tokenomics Best Practices for Devs"
+date: "2025-05-27"
 description: "A developer's guide to sustainable ERC20 token supply models. Explore inflation, deflation, capped supply, and dynamic mechanisms for robust tokenomics. Includes Solidity examples and real-world case studies."
 image: "/assets/guides/sustainable-erc20-supply.jpg"
+showNavigation: true
 ---
 
 ## TL;DR: Sustainable ERC20 Supply Models

--- a/packages/nextjs/guides/sustainable-tokenomics-staking-protocols.md
+++ b/packages/nextjs/guides/sustainable-tokenomics-staking-protocols.md
@@ -1,7 +1,9 @@
 ---
 title: "Beyond APY: Sustainable Tokenomics for Your Staking Protocol"
+date: "2025-05-16"
 description: "High APYs are just the start. Learn to engineer advanced tokenomics for your staking protocol focusing on intrinsic utility, smart supply dynamics, and aligned incentives for long-term value and sustainability. A guide for Web3 developers."
 image: /assets/guides/sustainable-tokenomics.jpg
+showNavigation: true
 ---
 
 So you're designing a staking protocol, or looking to improve an existing one. You know that offering rewards (APY) is key to attracting users. But if your strategy is just "offer the highest APY by printing tons of tokens," you might be setting yourself up for a short-lived hype cycle followed by a painful crash.

--- a/packages/nextjs/guides/time-weighted-staking-rewards.md
+++ b/packages/nextjs/guides/time-weighted-staking-rewards.md
@@ -1,7 +1,9 @@
 ---
 title: "Time-Weighted Staking Rewards & Dynamic APY in Solidity"
+date: "2025-05-13"
 description: "Go beyond basic staking! Learn to implement time-weighted rewards to incentivize long-term stakers and dynamic APYs that respond to market conditions in your Solidity contracts. A practical guide for Web3 devs aiming for fairer and more sustainable tokenomics."
 image: /assets/guides/time-weighted-rewards-dynamic-apy.jpg
+showNavigation: true
 ---
 
 So, you've got a staking contract. Users lock up tokens, earn rewards. Cool. But let's ask some real questions:

--- a/packages/nextjs/services/guides.ts
+++ b/packages/nextjs/services/guides.ts
@@ -129,8 +129,15 @@ const mdxComponents = {
 
 export async function getAllGuides(): Promise<Guide[]> {
   const slugs = getAllGuidesSlugs();
-  const guides = await Promise.all(slugs.map(getGuideBySlug));
-  return guides.filter(Boolean) as Guide[];
+  const guides = (await Promise.all(slugs.map(getGuideBySlug))).filter(Boolean) as Guide[];
+
+  // Newest first by date. Guides without a date keep their original (alphabetical) order after the dated ones.
+  return guides.sort((a, b) => {
+    if (a.date && b.date) return b.date.localeCompare(a.date);
+    if (a.date) return -1;
+    if (b.date) return 1;
+    return 0;
+  });
 }
 
 export function getAllGuidesSlugs(): string[] {


### PR DESCRIPTION
Small improvements added to our guides, to use on all the posts the recent table of contents and date fields that we added to the last article, and order the articles by the creation date. Also added an estimate reading time, feel free to delete if you feel its not needed 🙌

## Summary

- Enables the on-page **table of contents** (`showNavigation: true`) on all 24 guides. The TOC is built from the `##` (H2) headings.
- Backfills a `date` in each guide's frontmatter and **sorts the guides listing newest-first** by date. Dates drive ordering only and are **not shown anywhere in the UI** (neither on the listing cards nor on the article page), so the ~1 year gap between the newest guide and the rest is never surfaced.
- Shows **reading time** on each guide card and on the article hero.
- Fixes two heading-structure issues surfaced by the new TOC:
  - `flash-loan-exploits`: added the missing `## 2. The Anatomy of a Flash Loan Attack` so the section numbering no longer jumps 1 → 3.
  - `solidity-bonding-curves-token-pricing`: demoted a stray unnumbered `## Additional Security Risks` to an `###` so it no longer breaks the numbered TOC.

## How to test

1. `cd packages/nextjs && yarn dev`
2. Visit `/guides` — cards are ordered newest-first and show reading time (no dates shown).
3. Open any guide (e.g. `/guides/flash-loan-exploits`) — the left "On this page" nav appears on `lg+` screens, tracks the active section on scroll, and smooth-scrolls on click. The hero shows reading time only (no date). Check the section numbering reads 1 → 2 → 3… with no gaps.
4. Check `/guides/solidity-bonding-curves-token-pricing` — the TOC is a clean numbered 1–9 with no stray "Additional Security Risks" entry.

## Notes for reviewers

- Only content/markdown + small component changes; no DB, auth, or API changes.
- The dates are estimates anchored to each file's first git-add date, then spread ~2/week so they don't cluster — they're kept in frontmatter purely to drive ordering and are easy to adjust later. Because they aren't rendered, they can be corrected anytime without any visible impact.

<details>
<summary>Files changed</summary>

- `services/guides.ts` — `getAllGuides()` sorts by `date` desc; undated guides keep their original order after dated ones.
- `app/guides/[slug]/page.tsx` — removed the date from the article hero (reading time only).
- `app/guides/_components/SearchGuides.tsx` — adds reading time to each card.
- 23 guide markdown files — added `showNavigation: true` + `date` to frontmatter (the 24th already had both).
- `flash-loan-exploits.md`, `solidity-bonding-curves-token-pricing.md` — heading fixes described above.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJEc9PnNh8uQKTLHFDYXkY