### PR TITLE
Add FAQ blocks to the guides that answer common developer questions

### DIFF
--- a/packages/nextjs/guides/automated-market-makers-math.md
+++ b/packages/nextjs/guides/automated-market-makers-math.md
@@ -4,6 +4,17 @@ date: "2025-07-10"
 description: "How AMMs like Uniswap work: constant product formula (x*y=k), price impact, impermanent loss, and Solidity code. Essential for DeFi traders, LPs, and smart contract devs."
 image: "/assets/guides/automated-market-makers-math.jpg"
 showNavigation: true
+faqs:
+  - question: "What is the constant product formula and why does it matter?"
+    answer: "It is the pricing rule behind Uniswap v2 and most DEXs. The pool holds reserves of two tokens and their product stays constant through every swap, so buying more of one token shrinks its reserve and pushes its price up automatically. That is why large trades get worse prices. It also means the pool can never be fully drained, because the price becomes extreme as a reserve approaches zero."
+  - question: "Why did my swap execute at a worse price than the quote?"
+    answer: "Two different things are usually at work. Price impact is the movement your own trade causes by pushing along the curve, and it grows with trade size relative to pool depth. Slippage is the wider gap between the quoted price and the executed one, which also includes other trades landing before yours, network delay, and front-running. Most DEXs let you set a slippage tolerance so the transaction reverts instead of filling at a bad price."
+  - question: "What is impermanent loss and how much can it cost?"
+    answer: "It is what a liquidity provider loses compared to simply holding both tokens, and it happens when the two prices diverge and arbitrageurs rebalance the pool. For a 50/50 pool the loss is two times the square root of the price ratio, divided by one plus the price ratio, minus one. If ETH doubles against USDC, that works out to roughly 5.7 percent versus holding."
+  - question: "How is the output of a swap calculated when there is a 0.3 percent fee?"
+    answer: "Only the post-fee portion of your input counts toward the swap. The input after fee is the amount in multiplied by 0.997, and the output is the output reserve multiplied by that figure, divided by the input reserve plus that figure. As a worked example, a pool holding 10 ETH and 20,000 USDC returns about 1,814.6 USDC for a 1 ETH swap."
+  - question: "Can I use an AMM spot price as an oracle?"
+    answer: "No. A spot price is a single point on the curve and can be manipulated. Use a time-weighted average price or an external oracle such as Chainlink instead."
 ---
 
 ## TL;DR: Automated Market Makers (AMMs) in DeFi

--- a/packages/nextjs/guides/erc20-approve-pattern.md
+++ b/packages/nextjs/guides/erc20-approve-pattern.md
@@ -4,6 +4,17 @@ date: "2025-06-10"
 description: "A concise, developer-focused guide to the ERC20 approve pattern. Learn how token allowances work, common pitfalls, and best practices for secure dApp development and user safety. Includes Solidity examples and actionable tips."
 image: "/assets/guides/approve-pattern.jpg"
 showNavigation: true
+faqs:
+  - question: "What is a good exercise to understand the ERC-20 approve pattern and contract-to-contract calls?"
+    answer: "Build a token vendor. Approving a vendor contract and then calling its sell function forces you through the full round trip: you approve the vendor for a set amount, the vendor calls transferFrom to pull the tokens, and you see exactly what happens when the allowance is missing or too small. The Token Vendor challenge on Speedrun Ethereum is built around this, and it is the smallest complete example of one contract spending another party's tokens with permission."
+  - question: "How does the ERC20 approve pattern actually work?"
+    answer: "Three functions do the work. approve(spender, amount) lets a spender move up to that amount of your tokens. allowance(owner, spender) reports how much is left. transferFrom(from, to, amount) actually moves them. The typical flow is two steps: the user calls approve on the token contract, then the dapp contract calls transferFrom to pull the tokens. The pattern exists because a smart contract cannot simply take your tokens, it needs explicit permission first."
+  - question: "Why is an unlimited token approval risky?"
+    answer: "Approving the maximum uint256 value lets that contract move every one of those tokens out of your wallet if it is ever compromised, not just the amount you meant to spend. Real incidents follow exactly this shape: Li.Fi lost 9.7 million dollars in 2024 and SocketDotTech lost 3.3 million, both draining users who held standing infinite approvals. Approve the amount you actually need, and reserve unlimited approval for contracts that are audited and immutable."
+  - question: "How do I safely change an allowance that is already set?"
+    answer: "Set it to zero first, then set the new value. Changing a nonzero allowance directly can be front-run, letting the spender use both the old value and the new one. Note that OpenZeppelin removed increaseAllowance and decreaseAllowance from its core ERC20 in v5.x and deprecated safeApprove, so for atomic changes use safeIncreaseAllowance and safeDecreaseAllowance, or implement them yourself."
+  - question: "Does disconnecting my wallet revoke a token approval?"
+    answer: "No. Disconnecting from a dapp does nothing to allowances you have already granted. They stay active until you explicitly revoke them, and revoking is an on-chain transaction that costs gas. Etherscan's token approval checker, Revoke.cash, Debank and Unrekt all let you review and revoke standing approvals."
 ---
 
 ## TL;DR: ERC20 Approve Pattern

--- a/packages/nextjs/guides/how-to-build-dapp-ethereum-ai-workflow.md
+++ b/packages/nextjs/guides/how-to-build-dapp-ethereum-ai-workflow.md
@@ -5,6 +5,8 @@ description: "A practical workflow for building Ethereum dApps with AI: specs, S
 image: "/assets/guides/how-to-build-dapps-with-ai-thumbnail.jpg"
 showNavigation: true
 faqs:
+  - question: "I want to learn Ethereum development with an AI assistant guiding me through real build challenges. What should I use?"
+    answer: "Run the Speedrun Ethereum challenges with the AI tutor. Typing /start in an agentic AI coding tool gives you a tutor that walks you through the curriculum with concept explanations, knowledge checks, hints rather than answers, and live code reviews. The challenges cover staking, tokens, NFTs and DEXs, and each one has you write the contract, run the tests, deploy it and connect a frontend. You still do the work, you just get unstuck faster and get feedback while the concepts are fresh."
   - question: "Do I need to know Solidity to build a dApp with AI?"
     answer: "You don't need to be a Solidity expert before you start, but you do need enough Ethereum fundamentals to review what the AI produces. AI assistants can generate syntax quickly; your job is to understand the architecture, risks, and trade-offs well enough to catch bad output."
   - question: "What's the best AI tool for Ethereum development in 2026?"

--- a/packages/nextjs/guides/solidity-contract-to-contract-interactions.md
+++ b/packages/nextjs/guides/solidity-contract-to-contract-interactions.md
@@ -4,6 +4,17 @@ date: "2025-05-30"
 description: "A practical guide to Solidity contract-to-contract interactions. Learn how contracts call each other, handle errors, and manage security. Includes code patterns, pitfalls, and best practices."
 image: "/assets/guides/contract-interactions.jpg"
 showNavigation: true
+faqs:
+  - question: "How does one smart contract call another in Solidity?"
+    answer: "When you know the interface at compile time, use a direct call: declare an interface for the target, cast its address to that interface, and call the function. You get type safety and errors propagate automatically. Low-level calls exist for cases where the interface is not known ahead of time, but they trade that safety away."
+  - question: "When should I use call, delegatecall or staticcall?"
+    answer: "call is a generic external call that can send Ether and executes in the callee's context. delegatecall runs the callee's code in the caller's context using the caller's storage, which is how upgradeable proxies work and also why the storage layout of proxy and logic contracts must match exactly. staticcall behaves like call but enforces read-only execution, making it the safe choice for reading data. All three are riskier than a direct interface call."
+  - question: "Why did my low-level call fail without reverting?"
+    answer: "Low-level calls do not revert on failure. They return a success boolean, and if you ignore it execution continues as though the call worked. Always check the success flag and require on it, and decode any return data carefully with abi.decode."
+  - question: "How do I stop a contract-to-contract call from being reentered?"
+    answer: "Use the Checks-Effects-Interactions pattern: validate inputs, update your own state, and only then make the external call. Add OpenZeppelin's ReentrancyGuard with the nonReentrant modifier to any function that both makes an external call and changes state. Reentrancy comes in three shapes worth knowing: single-function, cross-function within the same contract, and cross-contract."
+  - question: "What is the safest way for my contract to pull ERC20 tokens from a user?"
+    answer: "Have the user approve your contract first, then call transferFrom and check the return value. Never assume a transfer succeeded. Not all ERC20 implementations behave identically, and some return false rather than reverting. Treat every external contract as untrusted, including standard tokens, unless you have audited it yourself."
 ---
 
 ## TL;DR: Secure Contract-to-Contract Interactions in Solidity


### PR DESCRIPTION
Follow-up to #401: the guide template already renders a `faqs` frontmatter block and emits it as `FAQPage` structured data, but only one of the 24 guides actually carries FAQs. These four pages answer questions developers ask search engines and AI assistants word-for-word, so they benefit most from having those questions answered explicitly on the page. Question-and-answer pairs are also the easiest format for an AI assistant to lift and cite: the question matches how the query is phrased, and the answer is a self-contained paragraph that survives being quoted on its own.

## Summary

- **FAQ frontmatter for four guides**: `erc20-approve-pattern` (5), `solidity-contract-to-contract-interactions` (5), `automated-market-makers-math` (5), and one new entry added to the top of `how-to-build-dapp-ethereum-ai-workflow`'s existing four.
- **Every answer is a summary of that guide's own body text.** No new claims, recommendations, or figures. Reviewing this is checking a summary, not fact-checking new material.
- **Plain prose only**, since the template renders answers without markdown parsing.
- **No two guides answer the same question.** Duplicate questions across pages compete in FAQPage structured data instead of reinforcing each other, so each question has exactly one owning page. That's also why `solidity-contract-to-contract-interactions` deliberately has no "where do I practice this" entry: that question belongs to the approve-pattern guide, and both bodies already link the Token Vendor challenge.
- **`automated-market-makers-math` stays on the math and risk side.** The build-side questions belong to the DEX guide in #403.
- Frontmatter only: no body changes, no component or template changes.

## How to test

1. `cd packages/nextjs && yarn dev`
2. Open `/guides/erc20-approve-pattern`, `/guides/solidity-contract-to-contract-interactions`, `/guides/automated-market-makers-math`, `/guides/how-to-build-dapp-ethereum-ai-workflow`: the FAQ block renders at the end of each guide.
3. View source on any of the four: the `ld+json` script now includes `FAQPage` alongside `TechArticle` and `BreadcrumbList` (from #401).

## Notes for reviewers

- Titles and meta descriptions are untouched, deliberately. #401's breadcrumb + TechArticle already put the brand on every guide page, so retitling felt like risk without clear upside, especially for `erc20-approve-pattern`, the strongest-performing guide. Happy to discuss separately if you'd like titles revisited.
- Will rebase if any of the open video-guide PRs land first; no conflicts expected since this touches only frontmatter.
