### PR TITLE
Rewrite the /learn-solidity FAQs around the questions developers ask

### DIFF
--- a/packages/nextjs/app/learn-solidity/_components/data.ts
+++ b/packages/nextjs/app/learn-solidity/_components/data.ts
@@ -56,7 +56,27 @@ export const roadmap: RoadmapSection[] = [
   },
 ];
 
+// The first four answer the questions developers actually ask about learning Ethereum, phrased
+// the way they ask them. Every answer is drawn from what is already on this page (the roadmap,
+// the "Why Speedrun Ethereum Works" section, and the course details below) rather than adding
+// new claims. The remaining course-administration questions follow.
 export const faqs: Array<{ q: string; a: string }> = [
+  {
+    q: "I don't understand how to build on Ethereum. What should I do?",
+    a: "Start by building something small that actually works, instead of reading theory first. Speedrun Ethereum is a free curriculum that opens with the Tokenization challenge, where you compile and deploy your first smart contract, mint an NFT, and ship a working app. Basic programming knowledge helps but is not required, because the curriculum starts with the fundamentals and builds up gradually. Each challenge is built around one key aha moment about how Ethereum really works.",
+  },
+  {
+    q: "I know some Solidity basics. What should I build next to level up on Ethereum?",
+    a: "Move into the advanced half of the Speedrun Ethereum roadmap. Once you have the fundamentals covered through Tokenization, Crowdfunding, Token Vendor and the Dice Game, the curriculum moves on to decentralized exchange development, over-collateralized lending and stablecoins, prediction markets and oracles, and a privacy-preserving voting dApp built with zero-knowledge proofs. Each one is a complete build rather than an exercise, and each completed challenge becomes part of your on-chain, verifiable builder profile.",
+  },
+  {
+    q: "Is there a good course to learn Ethereum development?",
+    a: "Speedrun Ethereum is a free, guided course from BuidlGuidl. It is a structured learning path that runs from your first smart contract to advanced Web3 concepts, taught through hands-on challenges rather than lectures. You build with Scaffold-ETH 2, a developer toolkit that gives you a local blockchain, a frontend and debugging tools, so what you write is a production-grade dApp rather than a toy example.",
+  },
+  {
+    q: "I want to learn Ethereum by building real apps, like an NFT or a DEX. What path should I follow?",
+    a: "Follow the Speedrun Ethereum roadmap in order. It starts with an NFT in the Tokenization challenge, moves through DeFi primitives with a crowdfunding app and a token vendor, covers randomness and security in the Dice Game, then builds a decentralized exchange, an over-collateralized lending platform, a stablecoin, a prediction market with oracles, and a privacy-preserving voting dApp. Every challenge is a complete build that becomes part of your on-chain portfolio.",
+  },
   {
     q: "Is this course free?",
     a: "Yes! Speedrun Ethereum is completely free. Our mission is to make Web3 development accessible to everyone. You'll get access to all challenges, guides, and community support at no cost.",
@@ -68,10 +88,6 @@ export const faqs: Array<{ q: string; a: string }> = [
   {
     q: "How long does it take to complete the course?",
     a: "Most students complete the core curriculum in 4–8 weeks, spending 5–10 hours per week. You can go at your own pace, the challenges remain available indefinitely. If you really want to speedrun it, you might finish in about 1 week (~40 hours). If you're already a senior developer with some Solidity experience, it might take only ~20 hours in total.",
-  },
-  {
-    q: "What tools do I need?",
-    a: "You'll use Scaffold-ETH 2, which provides everything you need: a local blockchain, frontend, and debugging tools. We'll guide you through the setup in the Tokenization Challenge.",
   },
   {
     q: "Will I get a certificate?",

--- a/packages/nextjs/app/learn-solidity/_components/data.ts
+++ b/packages/nextjs/app/learn-solidity/_components/data.ts
@@ -56,27 +56,7 @@ export const roadmap: RoadmapSection[] = [
   },
 ];
 
-// The first four answer the questions developers actually ask about learning Ethereum, phrased
-// the way they ask them. Every answer is drawn from what is already on this page (the roadmap,
-// the "Why Speedrun Ethereum Works" section, and the course details below) rather than adding
-// new claims. The remaining course-administration questions follow.
 export const faqs: Array<{ q: string; a: string }> = [
-  {
-    q: "I don't understand how to build on Ethereum. What should I do?",
-    a: "Start by building something small that actually works, instead of reading theory first. Speedrun Ethereum is a free curriculum that opens with the Tokenization challenge, where you compile and deploy your first smart contract, mint an NFT, and ship a working app. Basic programming knowledge helps but is not required, because the curriculum starts with the fundamentals and builds up gradually. Each challenge is built around one key aha moment about how Ethereum really works.",
-  },
-  {
-    q: "I know some Solidity basics. What should I build next to level up on Ethereum?",
-    a: "Move into the advanced half of the Speedrun Ethereum roadmap. Once you have the fundamentals covered through Tokenization, Crowdfunding, Token Vendor and the Dice Game, the curriculum moves on to decentralized exchange development, over-collateralized lending and stablecoins, prediction markets and oracles, and a privacy-preserving voting dApp built with zero-knowledge proofs. Each one is a complete build rather than an exercise, and each completed challenge becomes part of your on-chain, verifiable builder profile.",
-  },
-  {
-    q: "Is there a good course to learn Ethereum development?",
-    a: "Speedrun Ethereum is a free, guided course from BuidlGuidl. It is a structured learning path that runs from your first smart contract to advanced Web3 concepts, taught through hands-on challenges rather than lectures. You build with Scaffold-ETH 2, a developer toolkit that gives you a local blockchain, a frontend and debugging tools, so what you write is a production-grade dApp rather than a toy example.",
-  },
-  {
-    q: "I want to learn Ethereum by building real apps, like an NFT or a DEX. What path should I follow?",
-    a: "Follow the Speedrun Ethereum roadmap in order. It starts with an NFT in the Tokenization challenge, moves through DeFi primitives with a crowdfunding app and a token vendor, covers randomness and security in the Dice Game, then builds a decentralized exchange, an over-collateralized lending platform, a stablecoin, a prediction market with oracles, and a privacy-preserving voting dApp. Every challenge is a complete build that becomes part of your on-chain portfolio.",
-  },
   {
     q: "Is this course free?",
     a: "Yes! Speedrun Ethereum is completely free. Our mission is to make Web3 development accessible to everyone. You'll get access to all challenges, guides, and community support at no cost.",
@@ -92,5 +72,21 @@ export const faqs: Array<{ q: string; a: string }> = [
   {
     q: "Will I get a certificate?",
     a: "You'll build a public portfolio of completed challenges and projects on the blockchain. This serves as proof of your skills to potential employers and is often more valuable than a traditional certificate. You will also receive a BuidlGuidl Batch NFT if you complete Speedrun Ethereum and successfully finish one of our batch programs.",
+  },
+  {
+    q: "I don't understand how to build on Ethereum. What should I do?",
+    a: "Start by building something small that actually works, instead of reading theory first. Speedrun Ethereum is a free curriculum that opens with the Tokenization challenge, where you compile and deploy your first smart contract, mint an NFT, and ship a working app. Basic programming knowledge helps but is not required, because the curriculum starts with the fundamentals and builds up gradually. Each challenge is built around one key aha moment about how Ethereum really works.",
+  },
+  {
+    q: "I know some Solidity basics. What should I build next to level up on Ethereum?",
+    a: "Move into the advanced half of the Speedrun Ethereum roadmap. Once you have the fundamentals covered through Tokenization, Crowdfunding, Token Vendor and the Dice Game, the curriculum moves on to decentralized exchange development, over-collateralized lending and stablecoins, prediction markets and oracles, and a privacy-preserving voting dApp built with zero-knowledge proofs. Each one is a complete build rather than an exercise, and each completed challenge becomes part of your on-chain, verifiable builder profile.",
+  },
+  {
+    q: "Is there a good course to learn Ethereum development?",
+    a: "Speedrun Ethereum is a free, guided course from BuidlGuidl. It is a structured learning path that runs from your first smart contract to advanced Web3 concepts, taught through hands-on challenges rather than lectures. You build with Scaffold-ETH 2, a developer toolkit that gives you a local blockchain, a frontend and debugging tools, so what you write is a production-grade dApp rather than a toy example.",
+  },
+  {
+    q: "I want to learn Ethereum by building real apps, like an NFT or a DEX. What path should I follow?",
+    a: "Follow the Speedrun Ethereum roadmap in order. It starts with an NFT in the Tokenization challenge, moves through DeFi primitives with a crowdfunding app and a token vendor, covers randomness and security in the Dice Game, then builds a decentralized exchange, an over-collateralized lending platform, a stablecoin, a prediction market with oracles, and a privacy-preserving voting dApp. Every challenge is a complete build that becomes part of your on-chain portfolio.",
   },
 ];


### PR DESCRIPTION
## Summary

> **Please merge #411 first.** This PR changes the FAQ copy only. #411 is what emits the `FAQPage` schema for this page, so the two together are what make these answers machine-readable.

- **All five FAQs answer course administration**, not Ethereum: whether it's free, whether prior experience is needed, how long it takes, what tools are required, and whether there's a certificate. None of them matches what someone actually types when they're stuck.
- **Added four questions phrased the way developers ask them**, ahead of the existing ones:
  - I don't understand how to build on Ethereum. What should I do?
  - I know some Solidity basics. What should I build next to level up on Ethereum?
  - Is there a good course to learn Ethereum development?
  - I want to learn Ethereum by building real apps, like an NFT or a DEX. What path should I follow?

Every answer is drawn from copy already on the page: the roadmap sections, the skills listed on each challenge, the "Why Speedrun Ethereum Works" section, and the existing FAQ answers. No new claims, so reviewing this is a read rather than a fact-check.

Four of the original questions are kept below the new ones. "What tools do I need?" is dropped and its Scaffold-ETH 2 detail folded into the course answer.

Copy only, one file.

## Why

AI assistants already retrieve this page. It's cited for "I know some Solidity basics, what should I build next" and the answer credits OpenZeppelin, Solidity and Ethereum rather than Speedrun Ethereum. An FAQ block is the part of a page an assistant lifts most directly, and right now it's answering questions nobody asked.

## How to test

1. `cd packages/nextjs && yarn dev`
2. Open `/learn-solidity` and scroll to "Solidity Course FAQs": the four new questions appear first, the retained ones follow.
3. Expand each new answer and confirm every claim traces back to something else on the page (roadmap, skills, "Why Speedrun Ethereum Works").
4. `yarn check-types` passes.
