### PR TITLE
Add /build-prompts to sitemap.xml

### DIFF
--- a/packages/nextjs/public/sitemap.xml
+++ b/packages/nextjs/public/sitemap.xml
@@ -21,6 +21,11 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://speedrunethereum.com/build-prompts</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://speedrunethereum.com/challenge/tokenization</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
## Summary

`/build-prompts` is missing from `public/sitemap.xml`. The file lists 38 URLs and this isn't one of them.

The page is otherwise healthy: it returns 200, emits a self-referencing canonical, and is already listed in `llms.txt`. It looks like it was simply missed when the sitemap was last updated.

Added with `weekly` / `0.9`, matching the other top-level index pages (`/guides`, `/learn-solidity`).

## How to test

1. `cd packages/nextjs && yarn dev`
2. Visit `http://localhost:3000/sitemap.xml` and confirm `/build-prompts` is present and the XML still parses.
