### PR TITLE
Use the publication date, not the source video date, in guide frontmatter

### DIFF
--- a/packages/nextjs/guides/ai-agents-ethereum-x402-erc8004.md
+++ b/packages/nextjs/guides/ai-agents-ethereum-x402-erc8004.md
@@ -1,6 +1,6 @@
 ---
 title: "AI Agents and Ethereum: x402 Payments, ERC-8004, and Building the App"
-date: "2025-11-27"
+date: "2026-08-05"
 description: "Austin Griffith's Columbia University guest lecture on where AI agents and Ethereum meet: the x402 payment standard with a working client, server and facilitator, the ERC-8004 agent registry, and a full Scaffold-ETH 2 build deployed to Arbitrum. Full video and edited transcript."
 image: "/assets/guides/ai-agents-ethereum-x402-erc8004.jpg"
 showNavigation: true

--- a/packages/nextjs/guides/deploy-your-first-contract-to-an-l2.md
+++ b/packages/nextjs/guides/deploy-your-first-contract-to-an-l2.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploy Your First Smart Contract to an L2, with Scaffold-ETH 2"
-date: "2025-08-19"
+date: "2026-08-05"
 description: "Austin Griffith and Elliot Friedman take a counter contract from an empty folder to a live deployment on Arbitrum: scaffold, tinker locally, fund a deployer, deploy for a fraction of a cent, then bridging, the address table precompile, and forced transactions. Full video and edited transcript."
 image: "/assets/guides/deploy-your-first-contract-to-an-l2.jpg"
 showNavigation: true

--- a/packages/nextjs/guides/getting-front-run-on-purpose.md
+++ b/packages/nextjs/guides/getting-front-run-on-purpose.md
@@ -1,6 +1,6 @@
 ---
 title: "Getting Front-Run on Purpose: What the Mempool Really Exposes"
-date: "2023-09-04"
+date: "2026-08-05"
 description: "Austin Griffith deliberately ships a front-runnable commit-reveal contract to mainnet to find out whether MEV bots are watching. Optimism ignores it. Ethereum mainnet takes the money in one block. Full video and edited transcript."
 image: "/assets/guides/getting-front-run-on-purpose.jpg"
 showNavigation: true

--- a/packages/nextjs/guides/how-a-full-stack-ethereum-app-is-structured.md
+++ b/packages/nextjs/guides/how-a-full-stack-ethereum-app-is-structured.md
@@ -1,6 +1,6 @@
 ---
 title: "How a Full-Stack Ethereum App Is Structured, with Scaffold-ETH 2"
-date: "2025-06-04"
+date: "2026-08-05"
 description: "Austin Griffith walks through the anatomy of a full-stack Ethereum app at Devcon SEA: the two packages, the local chain, the tinker loop, and the Speedrun Ethereum curriculum that builds on it. Full video and edited transcript."
 image: "/assets/guides/how-a-full-stack-ethereum-app-is-structured.jpg"
 showNavigation: true


### PR DESCRIPTION
Thanks @carletex for catching the date on the L2 guide in #416. That was a typo on our side, and pulling on it turned up a wider inconsistency worth fixing in the same place.

## What was wrong

Four of the guides we shipped yesterday were dated to the talk or stream they were derived from, rather than to the day the guide went live:

| Guide | Was | Source |
| --- | --- | --- |
| `getting-front-run-on-purpose` | 2023-09-04 | Bow Tie Friday stream |
| `how-a-full-stack-ethereum-app-is-structured` | 2025-06-04 | Devcon SEA talk |
| `deploy-your-first-contract-to-an-l2` | 2025-08-19 | Arbitrum video (the one you fixed) |
| `ai-agents-ethereum-x402-erc8004` | 2025-11-27 | Columbia lecture |

Dating a derived guide to its source material is defensible in isolation, and that was the reasoning at the time. It is inconsistent with the other 26 guides, all of which use the publication date, and it turns out to have real side effects.

## Why the publication date is the better value here

**It feeds `datePublished` in the structured data.** `getGuideStructuredData()` passes `guide.date` straight through to the `TechArticle` node. So the schema on a page published yesterday was announcing 2023. Recency is one of the few freshness signals a crawler or an assistant can read directly off a page, and we were handing over the wrong one on our newest content. `/guides/getting-front-run-on-purpose` is currently serving `"datePublished":"2023-09-04"`.

**It drives the order of the guides index.** The index sorts on this field, so three of the four sorted below guides that genuinely are much older. The newest material on the site was the hardest to find on it.

**It is what the field means everywhere else.** Every other guide uses publication date, so a reader or a tool comparing two guides was comparing two different things.

The age of the underlying video still matters to a reader, but it belongs in the body, where each of these guides already states it, rather than in a field that feeds schema and sorting.

## Concretely

All four set to `2026-08-05`, the day they merged. Frontmatter only, one line per file, no content changes.

## How to test

```bash
cd packages/nextjs && yarn dev
```

- `/guides` lists the four near the top rather than scattered through the back half.
- View source on `/guides/getting-front-run-on-purpose`: `datePublished` reads 2026-08-05.
